### PR TITLE
Release: anyscale-operator 0.1.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: anyscale-operator
-version: 0.0.3
+version: 0.1.0

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -155,6 +155,26 @@ data:
     {{- end }}
 
     ########################################
+    # Instance Type Configurations (put these below the other patches so
+    # that instance-type specific patches can override the default patches).
+    ########################################
+    {{- $defaultInstanceTypesCopy := deepCopy (default dict .Values.defaultInstanceTypes) }}
+    {{- $additionalInstanceTypesCopy := deepCopy (default dict .Values.additionalInstanceTypes) }}
+    {{- $instanceTypes := merge $defaultInstanceTypesCopy $additionalInstanceTypesCopy }}
+    {{- range $instanceType, $config := $instanceTypes }}
+      {{- if $config.nodeSelector }}
+    - kind: Pod
+      selector: "anyscale.com/instance-type in ({{ $instanceType }})"
+      patch:
+        {{- range $key, $value := $config.nodeSelector }}
+        - op: add
+          path: /spec/nodeSelector/{{ $key | replace "/" "~1" }}
+          value: "{{ $value }}"
+        {{- end }}
+      {{- end }}
+    {{- end }}
+
+    ########################################
     # Additional Patches
     ########################################
     {{- if .Values.additionalPatches}}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -39,6 +39,9 @@ operatorResources:
 
 # defaultInstanceTypes provides a list of default Pod shapes that can be
 # used in Anyscale workloads (abstracted as virtual "instance types").
+#
+# Node selectors that apply specifically to these instance types can be
+# placed directly under each instance type under the `nodeSelector` key.
 defaultInstanceTypes:
   2CPU-8GB:
     resources:


### PR DESCRIPTION
- Adds better support for per-instance type NodeSelectors
- Backwards-compatible