### PR TITLE
Anyscale Operator 0.3.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: anyscale-operator
-version: 0.2.0
+version: 0.3.0

--- a/charts/anyscale-operator/templates/anyscale_head_pdb.yaml
+++ b/charts/anyscale-operator/templates/anyscale_head_pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.enableAnyscaleRayHeadNodePDB }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: anyscale-ray-head-nodes
+  namespace: {{ .Release.Namespace }}
+spec:
+  maxUnavailable: 0  # No head node can ever be evicted
+  unhealthyPodEvictionPolicy: AlwaysAllow  # Allows eviction of unhealthy head pods
+  selector:
+    matchLabels:
+      ray-node-type: head
+{{- end }}

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -76,7 +76,7 @@ data:
       selector: "anyscale.com/market-type in (ON_DEMAND)"
       patch:
         - op: add
-          path: /spec/nodeSelector/eks.amazonaws.com~1capacityType
+          path: {{ ternary "/spec/nodeSelector/karpenter.sh~1capacity-type" "/spec/nodeSelector/eks.amazonaws.com~1capacityType" .Values.enableKarpenterSupport }}
           value: "ON_DEMAND"
         - op: add
           path: /metadata/annotations/cluster-autoscaler.kubernetes.io~1safe-to-evict
@@ -85,7 +85,7 @@ data:
       selector: "anyscale.com/market-type in (SPOT)"
       patch:
         - op: add
-          path: /spec/nodeSelector/eks.amazonaws.com~1capacityType
+          path: {{ ternary "/spec/nodeSelector/karpenter.sh~1capacity-type" "/spec/nodeSelector/eks.amazonaws.com~1capacityType" .Values.enableKarpenterSupport }}
           value: "SPOT"
     {{- else if eq .Values.cloudProvider "gcp" }}
     - kind: Pod

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -38,7 +38,12 @@ spec:
         {{- if gt (int .Values.operatorReplicas) 1 }}
         - --enable-leader-election=true
         - --leader-election-lease-namespace={{ .Release.Namespace }}
-        - --leader-election-lease-name="anyscale-operator-lease"
+        - --leader-election-lease-name=anyscale-operator-lease
+        {{- end }}
+        {{- if .Values.operatorExcludeComponentVerification }}
+        {{- range .Values.operatorExcludeComponentVerification }}
+        - --exclude-component-verification={{ . }}
+        {{- end }}
         {{- end }}
         resources:
 {{ toYaml .Values.operatorResources.operator | indent 10 }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-af10d5eb875fca7a4c06c319e7a4ab01c8ecf325"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-cd1e11a0eae946ead3bc57949c480bb82ef5a9b1"
 
 # operatorIamIdentity specifies the IAM identity from the cloud provider to bind to the Anyscale Operator.
 # This is only supported on AWS/GCP. For AWS, this should be the ARN of the IAM role. For GCP, this should be the email of the
@@ -38,6 +38,15 @@ operatorResources:
       memory: 512Mi
 
 operatorReplicas: 1
+
+# operatorExcludeComponentVerification allows specifying components to skip verification for during the
+# operator startup sequence.
+#
+# Valid values are:
+#  - STORAGE_BUCKET
+#
+# By default, all components will be verified during the operator startup sequence.
+operatorExcludeComponentVerification: []
 
 # defaultInstanceTypes provides a list of default Pod shapes that can be
 # used in Anyscale workloads (abstracted as virtual "instance types").
@@ -164,3 +173,12 @@ workloadDefaultTolerances:
 #
 # This can be either an IP address or a hostname.
 ingressAddress: ""
+
+
+# If set to true, this will create a PodDisruptionBudget to avoid
+# head node evictions.
+# This could block the k8s cluster upgrade or maintenance.
+# If enabled, remember to delete the PDB before upgrading the cluster.
+enableAnyscaleRayHeadNodePDB: false
+
+enableKarpenterSupport: false


### PR DESCRIPTION
# Summary

Regular minor release with backwards-compatible features.

# Changes

## New Values

- `enableAnyscaleRayHeadNodePDB`: adds Pod Disruption Budget to prevent eviction of Head Node Pods managed by Operator. Default `false`, will be `true` in future release
- `enableKarpenterSupport`: enable features to support [Karpenter](https://karpenter.sh/) K8s autoscaler with Anyscale Operator. Default `false`
- `operatorExcludeComponentVerification`: components to skip verification for during the operator startup sequence. Valid values are: `STORAGE_BUCKET`

## Other

- `version` updated to `0.3.0`
- Updated Operator image
