### PR TITLE
Anyscale Operator 0.4.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,3 +1,4 @@
 apiVersion: v2
+description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.3.0
+version: 0.4.0

--- a/charts/anyscale-operator/templates/anyscale_cli_token_secret.yaml
+++ b/charts/anyscale-operator/templates/anyscale_cli_token_secret.yaml
@@ -4,6 +4,11 @@ kind: Secret
 metadata:
   name: anyscale-cli-token
   namespace: {{ .Release.Namespace }}
+  labels:
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   ANYSCALE_CLI_TOKEN: {{ .Values.anyscaleCliToken | b64enc }}

--- a/charts/anyscale-operator/templates/anyscale_head_pdb.yaml
+++ b/charts/anyscale-operator/templates/anyscale_head_pdb.yaml
@@ -4,6 +4,11 @@ kind: PodDisruptionBudget
 metadata:
   name: anyscale-ray-head-nodes
   namespace: {{ .Release.Namespace }}
+labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   maxUnavailable: 0  # No head node can ever be evicted
   unhealthyPodEvictionPolicy: AlwaysAllow  # Allows eviction of unhealthy head pods

--- a/charts/anyscale-operator/templates/cluster_role.yaml
+++ b/charts/anyscale-operator/templates/cluster_role.yaml
@@ -5,6 +5,11 @@ metadata:
   # launching multiple cloud deployments into a single Kubernetes cluster (we
   # assume that clouds to not share namespaces).
   name: anyscale-operator-token-reviewer-{{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]

--- a/charts/anyscale-operator/templates/cluster_role_binding.yaml
+++ b/charts/anyscale-operator/templates/cluster_role_binding.yaml
@@ -5,6 +5,11 @@ metadata:
   # launching multiple cloud deployments into a single Kubernetes cluster (we
   # assume that clouds to not share namespaces).
   name: anyscale-operator-token-reviewer-{{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/anyscale-operator/templates/configmap_instance_types.yaml
+++ b/charts/anyscale-operator/templates/configmap_instance_types.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     anyscale.com/name: instance-types
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   version: v1
   instance_types.yaml: |-

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -3,6 +3,11 @@ kind: ConfigMap
 metadata:
   name: patches
   namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   version: v1
   patches.yaml: |-
@@ -14,7 +19,19 @@ data:
       patch:
         - op: add
           path: /spec/serviceAccountName
-          value: {{ .Values.workloadServiceAccountName }}
+          value: "{{ .Values.workloadServiceAccountName }}"
+    {{- end }}
+
+    # Enable workload identity for azure
+    {{- if eq .Values.cloudProvider "azure" }}
+    - kind: Pod
+      patch:
+        - op: add
+          path: /metadata/labels/azure.workload.identity~1use
+          value: "true"
+        - op: add
+          path: /metadata/annotations/azure.workload.identity~1inject-proxy-sidecar
+          value: "true"
     {{- end }}
 
     ########################################
@@ -150,6 +167,15 @@ data:
           {{- else }}
           path: /spec/nodeSelector/cloud.google.com~1gke-accelerator
           {{- end }}
+          value: "{{ $value }}"
+    {{- end }}
+    {{- else if eq .Values.cloudProvider "azure" }}
+    {{- range $key, $value := .Values.supportedAccelerators.azure }}
+    - kind: Pod
+      selector: "anyscale.com/accelerator-type in ({{ $key }})"
+      patch:
+        - op: add
+          path: /spec/nodeSelector/nvidia.com~1gpu.product
           value: "{{ $value }}"
     {{- end }}
     {{- end }}

--- a/charts/anyscale-operator/templates/configmap_vector.yaml
+++ b/charts/anyscale-operator/templates/configmap_vector.yaml
@@ -121,3 +121,8 @@ kind: ConfigMap
 metadata:
   name: vector
   namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: anyscale-operator
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.operatorReplicas }}
   selector:
@@ -14,19 +18,33 @@ spec:
     metadata:
       labels:
         app: anyscale-operator
+        {{- if eq .Values.cloudProvider "azure" }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      {{- if eq .Values.cloudProvider "azure" }}
+      annotations:
+        azure.workload.identity/inject-proxy-sidecar: "true"
+      {{- end }}
     spec:
       serviceAccount: anyscale-operator
+      {{- if .Values.operatorNodeSelection.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.operatorNodeSelection.nodeSelector | indent 8 }}
+      {{- else if .Values.operatorNodeSelection.affinity }}
+      affinity:
+{{ toYaml .Values.operatorNodeSelection.affinity | indent 8 }}
+      {{- end }}
       containers:
       - name: operator
         image: "{{ required "operatorImage is required" .Values.operatorImage }}"
-        imagePullPolicy: {{or .Values.operatorImagePullPolicy "IfNotPresent"}}
+        imagePullPolicy: {{ .Values.operatorImagePullPolicy | default "IfNotPresent" }}
         command: ["/app/go/infra/kubernetes_manager/kubernetes_manager"]
         args:
         - --log-level=info
         - --log-file=/tmp/anyscale/logs/operator.log
         - start
         - --cloud-deployment-id={{ required "cloudDeploymentId is required" .Values.cloudDeploymentId }}
-        - --control-plane-url={{or .Values.controlPlaneURL "https://console.anyscale.com"}}
+        - --control-plane-url={{ .Values.controlPlaneURL | default "https://console.anyscale.com" }}
         - --cloud-provider={{ .Values.cloudProvider }}
         {{ if not .Values.anyscaleCliToken }}
         - --region={{ required "region is required for operator registration if anyscaleCliToken is not provided & cloud-native bootstrap scheme is used; must be set to the cloud provider region of this Kubernetes cluster" .Values.region }}

--- a/charts/anyscale-operator/templates/role.yaml
+++ b/charts/anyscale-operator/templates/role.yaml
@@ -3,6 +3,11 @@ kind: Role
 metadata:
   name: anyscale-operator
   namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps", "services", "pods", "secrets", "events"]

--- a/charts/anyscale-operator/templates/role_binding.yaml
+++ b/charts/anyscale-operator/templates/role_binding.yaml
@@ -3,6 +3,11 @@ kind: RoleBinding
 metadata:
   name: anyscale-operator
   namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/anyscale-operator/templates/service_account.yaml
+++ b/charts/anyscale-operator/templates/service_account.yaml
@@ -3,6 +3,11 @@ kind: ServiceAccount
 metadata:
   name: anyscale-operator
   namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- if .Values.operatorIamIdentity}}
   {{- if eq .Values.cloudProvider "aws" }}
   annotations:
@@ -10,5 +15,8 @@ metadata:
   {{- else if eq .Values.cloudProvider "gcp" }}
   annotations:
     iam.gke.io/gcp-service-account: {{ .Values.operatorIamIdentity }}
+  {{- else if eq .Values.cloudProvider "azure" }}
+  annotations:
+    azure.workload.identity/client-id: {{ .Values.operatorIamIdentity }}
   {{- end }}
   {{- end }}

--- a/charts/anyscale-operator/templates/validating_webhook.yaml
+++ b/charts/anyscale-operator/templates/validating_webhook.yaml
@@ -2,6 +2,11 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: anyscale-operator-{{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 webhooks:
 - name: instance-types.{{ .Release.Namespace }}.anyscale-operator.anyscale.com
   rules:

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-cd1e11a0eae946ead3bc57949c480bb82ef5a9b1"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-08a6e443535e5ba9f2c98a568d675293375ddfc3"
 
 # operatorIamIdentity specifies the IAM identity from the cloud provider to bind to the Anyscale Operator.
 # This is only supported on AWS/GCP. For AWS, this should be the ARN of the IAM role. For GCP, this should be the email of the
@@ -47,6 +47,15 @@ operatorReplicas: 1
 #
 # By default, all components will be verified during the operator startup sequence.
 operatorExcludeComponentVerification: []
+
+# operatorNodeSelection allows configuring where the Anyscale Operator pods are scheduled.
+# Either nodeSelector or affinity can be specified
+# If both are specified, nodeSelector takes precedence.
+operatorNodeSelection:
+  # nodeSelector is a map of key-value pairs used for basic node selection
+  nodeSelector: {}
+  # affinity allows for more complex node selection rules
+  affinity: {}
 
 # defaultInstanceTypes provides a list of default Pod shapes that can be
 # used in Anyscale workloads (abstracted as virtual "instance types").
@@ -116,6 +125,11 @@ supportedAccelerators:
   aws:
     T4: "Tesla-T4"
     A10G: "NVIDIA-A10G"
+  azure:
+    T4: "NVIDIA-T4"
+    A10: "NVIDIA-A10"
+    A100: "NVIDIA-A100"
+    H100: "NVIDIA-H100"
   gcp:
     V100: "nvidia-tesla-v100"
     P100: "nvidia-tesla-p100"


### PR DESCRIPTION
# Summary

This release adds AKS (Azure Managed Kubernetes Service) support, optional Operator node selection configuration, and improved Operator and Anyscale workload Pod labeling.

This release is backward-compatible and is recommended for all users.

## New Values

`operatorNodeSelection` - allows configuring where the Anyscale Operator pods are scheduled.
- Either `nodeSelector` or `affinity` key can be specified
- If both are specified, nodeSelector takes precedence

### Examples
Scheduling on only nodes labeled `beta.kubernetes.io/os: linux` using `affinity.nodeAffinity`

```yaml
# see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/#schedule-a-pod-using-required-node-affinity
operatorNodeSelection:
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - preference:
            matchExpressions:
              - key: beta.kubernetes.io/os
                operator: In
                values:
                  - linux
          weight: 100
```

Scheduling on only nodes labeled `beta.kubernetes.io/os: linux` using `nodeSelector`

```yaml
# see: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
operatorNodeSelection:
  nodeSelector:
    beta.kubernetes.io/os: linux
```

## Updated Values

`cloudProvider` now supports `azure` for AKS. Setting this value adds required annotations for older AKS cluster workload identity support (`azure.workload.identity/inject-proxy-sidecar: "true"`) and enables accelerator support. See: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-annotations

`supportedAccelerators` has been updated with a `azure` key mapping supported GPU accelerator types.

## New Labels

In accordance with https://helm.sh/docs/chart_best_practices/labels/#standard-labels we've added these labels to all Helm-managed resources:

Name | Status | Description
-- | -- | --
app.kubernetes.io/name | REC | This should be the app name, reflecting the entire app. Usually {{ template "name" . }} is used for this. This is used by many Kubernetes manifests, and is not Helm-specific.
helm.sh/chart | REC | This should be the chart name and version: {{ .Chart.Name }}-{{ .Chart.Version \| replace "+" "_" }}.
app.kubernetes.io/managed-by | REC | This should always be set to {{ .Release.Service }}. It is for finding all things managed by Helm.
app.kubernetes.io/instance | REC | This should be the {{ .Release.Name }}. It aids in differentiating between different instances of the same application.

## Other

Updated the Kubernetes Operator image:
- Fixed cloud storage presigned url verification issue
- Fixed logrotate issue for containers without `ubuntu` user
- Small refactors and improvements