### PR TITLE
Anyscale Operator 0.5.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.4.0
+version: 0.5.0

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -50,6 +50,12 @@ spec:
         - --region={{ required "region is required for operator registration if anyscaleCliToken is not provided & cloud-native bootstrap scheme is used; must be set to the cloud provider region of this Kubernetes cluster" .Values.region }}
         {{ end }}
         - --patch-config-path=/tmp/config/patches.yaml
+        {{- if .Values.enableGateway }}
+        - --enable-gateway=true
+        - --gateway-name={{ .Values.gatewayName }}
+        - --gateway-hostname={{ .Values.gatewayHostname }}
+        - --gateway-ip={{ .Values.gatewayIp }}
+        {{- end }}
         - --system-logs-ingress-proxy-port=3100
         - --system-metrics-ingress-proxy-port=3101
         - --vector-enrichment-table-path=/tmp/config/vector/runtime_metadata.csv

--- a/charts/anyscale-operator/templates/role.yaml
+++ b/charts/anyscale-operator/templates/role.yaml
@@ -15,6 +15,11 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+{{- if .Values.enableGateway }}
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes"]
+  verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+{{- end }}
 {{- if gt (int .Values.operatorReplicas) 1 }}
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-08a6e443535e5ba9f2c98a568d675293375ddfc3"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-bbdd5c6b3eb955e144f0a15f6f5366a30d2a8012"
 
 # operatorIamIdentity specifies the IAM identity from the cloud provider to bind to the Anyscale Operator.
 # This is only supported on AWS/GCP. For AWS, this should be the ARN of the IAM role. For GCP, this should be the email of the
@@ -193,6 +193,24 @@ ingressAddress: ""
 # head node evictions.
 # This could block the k8s cluster upgrade or maintenance.
 # If enabled, remember to delete the PDB before upgrading the cluster.
-enableAnyscaleRayHeadNodePDB: false
+enableAnyscaleRayHeadNodePDB: true
 
 enableKarpenterSupport: false
+
+## Gateway related values.
+
+# enableGateway controls whether to enable the gateway functionality.
+# When set to true, the load balancing is done through the gateway.
+enableGateway: false
+
+# gatewayName specifies the name of the gateway to be used.
+# This is used to identify the gateway resource in the k8s cluster.
+gatewayName: ""
+
+# gatewayIp specifies the IP address of the gateway.
+# This is used for routing traffic through the gateway.
+gatewayIp: ""
+
+# gatewayHostname specifies the hostname of the gateway.
+# This is used for routing traffic through the gateway.
+gatewayHostname: ""


### PR DESCRIPTION
Standard merge into upstream for v0.5.0.  Few new features, one default change, and backwards-compatibility. Ready for final testing and sign-off. Proposed release notes are below:

---------

# Release `0.5.0`

This release adds Kubernetes Gateway API support, RPC support for cluster termination without Anyscale's control plane, and enables Pod Disruption Budgets for Ray Head Nodes by default.

This release is backward-compatible and is recommended for all users. See `Updated Values` if you do not wish to enable Head Node PDBs.

## New Values

### Gateway API Support
See: [Gateway API K8s Docs](https://gateway-api.sigs.k8s.io/)

To enable support, set `enableGateway: true` as well as the `gateway*` values.

Name | Description | Default
-- | -- | --
enableGateway |  Controls whether to enable the gateway functionality. When set to true, the load balancing is done through the gateway. | false
gatewayName | Specifies the name of the gateway to be used. This is used to identify the gateway resource in the k8s cluster. | ""
gatewayIp | Specifies the IP address of the gateway. This is used for routing traffic through the gateway. | ""
gatewayHostname | Specifies the hostname of the gateway. This is used for routing traffic through the gateway. | ""

#### Gateway config action
Add tls terminate secret to the gateway configuration.
```yaml
  spec:
    gatewayClassName: <gateway-class>
    listeners:
    - allowedRoutes:
        namespaces:
          from: Same
      name: http
      port: 80
      protocol: HTTP
    - allowedRoutes:
        namespaces:
          from: Same
      name: https
      port: 443
      protocol: HTTPS
      tls:
        certificateRefs:
        - group: ""
          kind: Secret
          name: anyscale-cldrsrc-<deployment-id>-certificate
          namespace: <anyscale-namespace>
        mode: Terminate
```


## Updated Values

`enableAnyscaleRayHeadNodePDB` is now set to default to `true`: this enables [Pod Disruption Budgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for the Ray Head Node Pods, improving their reliability in environments which may otherwise terminate and re-create them.

If you do not wish to enable this feature, set `enableAnyscaleRayHeadNodePDB: false`.

## Other

### Cluster Termination RPC
- Enables cluster termination via RPC to the Anyscale Operator directly

#### Prerequisites

- Kubernetes cluster access
- `kubectl` installed
- `grpcurl` installed for accessing gRPC endpoints

#### Setup

1. Login to your Kubernetes cluster
2. Port forward the service:
```bash
kubectl -n <anyscale-namespace> port-forward anyscale-operator-<operator_id> 3915:3915
```

#### Available Endpoints

##### GetKubernetesManagerConfig

Retrieves the current configuration state of the Kubernetes manager.

**Request:**
```bash
grpcurl -d '{}' -plaintext localhost:3915 anyscale.kubernetes_manager.KubernetesManager/GetKubernetesManagerConfig
```

**Response Example:**
```json
{
  "config": {
    "pendingTerminationWorkloads": {},
    "terminatedWorkloads": {}
  }
}
```

##### TerminateWorkload

Marks an Anyscale workload as terminated and cleans up associated resources.

**Request Example:**
```bash
grpcurl -d '{
  "cluster_id": "<cluster_id>",
  "namespace": "<anyscale-namespace>"
}' -plaintext localhost:3915 anyscale.kubernetes_manager.KubernetesManager/TerminateWorkload
```

**Request Parameters:**
- `cluster_id` (string, optional): Unique identifier of the Anyscale cluster to be terminated
- `job_id` (string, optional): Unique identifier of the Anyscale job to be terminated
- `job_queue_id` (string, optional): Unique identifier of the Anyscale job queue to be terminated
- `service_id` (string, optional): Unique identifier of the Anyscale service to be terminated
- `namespace` (string): Namespace where the workload pods are running

**Response:**
Empty response indicating successful termination

## Kubernetes Operator Updates

### Updated the Kubernetes Operator image:
- Support for new features
- Improved AWS IAM role credential signing
- Small refactors and improvements