### PR TITLE
Fix indentation of labels map

### DIFF
--- a/charts/anyscale-operator/templates/anyscale_cli_token_secret.yaml
+++ b/charts/anyscale-operator/templates/anyscale_cli_token_secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: anyscale-cli-token
   namespace: {{ .Release.Namespace }}
   labels:
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      app.kubernetes.io/name: {{ .Chart.Name }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   ANYSCALE_CLI_TOKEN: {{ .Values.anyscaleCliToken | b64enc }}

--- a/charts/anyscale-operator/templates/anyscale_head_pdb.yaml
+++ b/charts/anyscale-operator/templates/anyscale_head_pdb.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: anyscale-ray-head-nodes
   namespace: {{ .Release.Namespace }}
-labels:
+  labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
There is an incorrect indentation on the PDB resource such that the `labels` map is not under the `metadata` map which is invalid for this resource. This PR hopes to fix that. Also, there was an inconsistent number of indentations for the `labels` map contents in the Secret resource, which is just cosmetic.

This PR should hopefully resolve [Issue 13](https://github.com/anyscale/helm-charts/issues/13).