### PR TITLE
Anyscale Operator 0.5.2

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.5.1
+version: 0.5.2

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -48,7 +48,7 @@ data:
             key: {{ $k }}
             operator: {{ if $v.value }}Equal{{- else }}Exists{{- end }}
             {{- if $v.value }}
-            value: {{ $v.value }}
+            value: {{ quote $v.value }}
             {{- end }}
             effect: {{ $v.effect | default "NoSchedule" }}
         {{- end }}
@@ -64,7 +64,7 @@ data:
             key: {{ $k }}
             operator: {{ if $v.value }}Equal{{- else }}Exists{{- end }}
             {{- if $v.value }}
-            value: {{ $v.value }}
+            value: {{ quote $v.value }}
             {{- end }}
             effect: {{ $v.effect | default "NoSchedule" }}
         {{- end }}
@@ -80,7 +80,7 @@ data:
             key: {{ $k }}
             operator: {{ if $v.value }}Equal{{- else }}Exists{{- end }}
             {{- if $v.value }}
-            value: {{ $v.value }}
+            value: {{ quote $v.value }}
             {{- end }}
             effect: {{ $v.effect | default "NoSchedule" }}
         {{- end }}


### PR DESCRIPTION
# Release `0.5.2`

Bugfix for handling user-specified `Values.workloadDefaultTolerances` which may be interpreted as `boolean` instead of `string` type

This release is backwards compatible and recommended for all users.