### PR TITLE
Bugfix for Karpenter labeling when using `enableKarpenterSupport: true`

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.5.2
+version: 0.5.3

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -92,18 +92,30 @@ data:
     - kind: Pod
       selector: "anyscale.com/market-type in (ON_DEMAND)"
       patch:
+      {{- if .Values.enableKarpenterSupport }}
         - op: add
-          path: {{ ternary "/spec/nodeSelector/karpenter.sh~1capacity-type" "/spec/nodeSelector/eks.amazonaws.com~1capacityType" .Values.enableKarpenterSupport }}
+          path: "/spec/nodeSelector/karpenter.sh~1capacity-type"
+          value: "on-demand"
+      {{- else }}
+        - op: add
+          path: "/spec/nodeSelector/eks.amazonaws.com~1capacityType"
           value: "ON_DEMAND"
+     {{- end }}
         - op: add
           path: /metadata/annotations/cluster-autoscaler.kubernetes.io~1safe-to-evict
           value: "false"
     - kind: Pod
       selector: "anyscale.com/market-type in (SPOT)"
       patch:
+      {{- if .Values.enableKarpenterSupport }}
         - op: add
-          path: {{ ternary "/spec/nodeSelector/karpenter.sh~1capacity-type" "/spec/nodeSelector/eks.amazonaws.com~1capacityType" .Values.enableKarpenterSupport }}
+          path: "/spec/nodeSelector/karpenter.sh~1capacity-type"
+          value: "spot"
+      {{- else }}
+        - op: add
+          path: "/spec/nodeSelector/eks.amazonaws.com~1capacityType"
           value: "SPOT"
+      {{- end }}
     {{- else if eq .Values.cloudProvider "gcp" }}
     - kind: Pod
       selector: "anyscale.com/market-type in (SPOT)"


### PR DESCRIPTION
# Release `0.5.3`

Bugfix for handling Karpenter-specific scheduling labels. Karpenter using lowercase `on-demand` instead of EKS and others' `ON_DEMAND`.

This release is backward compatible and recommended for those using [Karpenter](https://karpenter.sh/).