### PR TITLE
Add support for custom operator pod tolerations

### DIFF
--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       affinity:
 {{ toYaml .Values.operatorNodeSelection.affinity | indent 8 }}
       {{- end }}
+      {{- if .Values.operatorNodeSelection.tolerations }}
+      tolerations:
+{{ toYaml .Values.operatorNodeSelection.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: operator
         image: "{{ required "operatorImage is required" .Values.operatorImage }}"

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,6 +56,8 @@ operatorNodeSelection:
   nodeSelector: {}
   # affinity allows for more complex node selection rules
   affinity: {}
+  # tolerations allow the operator pod to schedule on nodes with matching taints
+  tolerations: []
 
 # defaultInstanceTypes provides a list of default Pod shapes that can be
 # used in Anyscale workloads (abstracted as virtual "instance types").


### PR DESCRIPTION
## Summary
- Added support for custom tolerations in the anyscale-operator deployment
- Added `tolerations` array to `operatorNodeSelection` in values.yaml with empty default
- Updated deployment.yaml template to conditionally include tolerations section
- Maintains backward compatibility with existing configurations

## Test plan
- [x] Verified chart renders correctly with default empty tolerations array
- [x] Tested custom tolerations configuration (nvidia.com/gpu taint example)  
- [x] Confirmed tolerations appear correctly in rendered deployment spec

## Test Results

### Default Configuration Test
```bash
helm template test-release charts/anyscale-operator --set cloudDeploymentId=test --set cloudProvider=aws --set operatorImage=test:latest --set region=us-west-2
```
✅ **Result**: Template renders successfully with no tolerations section (expected behavior with empty array)

### Custom Tolerations Test
```bash
helm template test-release charts/anyscale-operator --set cloudDeploymentId=test --set cloudProvider=aws --set operatorImage=test:latest --set region=us-west-2 --set-json 'operatorNodeSelection.tolerations=[{"key":"nvidia.com/gpu","value":"present","effect":"NoSchedule"}]'
```
✅ **Result**: Template renders successfully with tolerations properly included:
```yaml
spec:
  template:
    spec:
      serviceAccount: anyscale-operator
      tolerations:
        - effect: NoSchedule
          key: nvidia.com/gpu
          value: present
      containers:
        # ... rest of spec
```

## Usage Example
For GPU nodes with nvidia.com/gpu taint:
```yaml
operatorNodeSelection:
  tolerations:
    - key: nvidia.com/gpu
      value: present
      effect: NoSchedule
```