### PR TITLE
Anyscale Operator 0.6.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.5.3
+version: 0.6.0

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -1,5 +1,101 @@
 # Anyscale Operator Helm Chart
 
-For now, refer to https://docs.google.com/document/d/1xlJlP2cJDN8rTzX6j3oIAHwupAbPtS9ymGeTcL8tH9Y/edit for updated installation instructions.
+The Anyscale Operator Helm Chart enables the deployment and management of Anyscale workloads on Kubernetes clusters. This chart provides a comprehensive set of configuration options to customize the operator's behavior according to your specific requirements.
 
-When we stabilize, we will migrate the Google Doc to a README that is included with this Helm chart.
+## Configuration
+
+The following sections detail the configurable parameters available in the chart. Each parameter is documented with its type, default value, and purpose.
+
+## Required values
+
+The following are required values for the Anyscale Operator.
+
+### Core Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cloudDeploymentId` | string | `""` | Anyscale cloud deployment ID (e.g. `cldrsrc_abcdefgh12345678ijklmnop12`). This is created when you register the Anyscale cloud. If you do not have this available, you can retrieve it using `anyscale cloud config get --name <cloud_name>`  |
+| `cloudProvider` | string | `""` | Cloud provider environment. Allowed values: `aws`, `gcp`, `azure`, `generic` |
+| `region` | string | `""` | Cloud region for deployment |
+| `anyscaleCliToken` | string | `""` | Anyscale CLI token for control plane authentication. Falls back to cloud provider identity if not set. This is required for Azure and Generic deployments. |
+| `operatorIamIdentity` | string | `""` | Cloud provider IAM identity (AWS role ARN , GCP service account email, Azure identity) |
+| `operatorImage` | string | `""` | Docker image to use for the Anyscale Operator. Updated with helm releases. Anyscale support may provide preview version of image for debugging. |
+
+## Advanced Configuration
+
+For advanced usage consult with Anyscale support.
+
+### Kubernetes Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `workloadServiceAccountName` | string | `""` | Service account for Anyscale workload pods |
+| `kubeConfigPath` | string | `""` | Path to kubeconfig file. Suggested to use the defaults. For advanced usage consult with Anyscale support. |
+| `kubernetesClientRateLimiterQPS` | float32 | `1000` | Kubernetes API server QPS rate limit. Suggested to use the defaults. For advanced usage consult with Anyscale support. |
+| `kubernetesClientRateLimiterBurst` | int | `2000` | Kubernetes API server burst rate limit. Suggested to use the defaults. For advanced usage consult with Anyscale support. |
+| `additionalPatches` | array | `[]` | Additional patches that will be applied to Pods and other Kubernetes resources |
+| `workloadDefaultTolerances` | object | See values.yaml | Default tolerances for workloads (includes configurations for all, gpu, and spot workloads) |
+
+### Performance and Resource Management
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `unscheduledPodReaperReconcileInterval` | duration | `1m` | Unscheduled pod cleanup interval, reaper probes every default=1m, works together with unscheduled... at which point termination will occur |
+| `unscheduledPodReaperTerminationThreshold` | duration | `10m` | Time threshold for unscheduled pod termination. If a pod remains unscheduled beyond this duration, it will be terminated. |
+
+### High Availability
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `operatorReplicas` | int | `1` | Number of operator replicas, if the value is larger than 1, leader election will be enabled. |
+
+### Resource Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `operatorResources.operator.requests.memory` | string | `512Mi` | Operator container memory request |
+| `operatorResources.operator.requests.cpu` | string | `1` | Operator container CPU request |
+| `operatorResources.operator.limits.memory` | string | `2Gi` | Operator container memory limit |
+| `operatorResources.vector.requests.cpu` | string | `100m` | Vector sidecar CPU request |
+| `operatorResources.vector.requests.memory` | string | `512Mi` | Vector sidecar memory request |
+| `operatorResources.vector.limits.memory` | string | `512Mi` | Vector sidecar memory limit |
+
+### Instance Types and Resources
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `defaultInstanceTypes` | object | See values.yaml | Default pod resource configurations |
+| `additionalInstanceTypes` | object | `{}` | Additional pod resource configurations |
+| `supportedAccelerators` | object | See values.yaml | Accelerator type mappings for scheduling |
+| `acceleratorNodeSelector` | string | `""` | Node selector key to use when scheduling pods with accelerators. If not set, the default key for the cloud provider will be used |
+
+### Networking
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ingressAddress` | string | `""` | DNS address for cluster ingress. Only required when needing to override what is provided by the ingress resource. |
+| `enableGateway` | bool | `false` | Enable gateway functionality for load balancing |
+| `gatewayName` | string | `""` | Name of the gateway to be used |
+| `gatewayIp` | string | `""` | IP address of the gateway. Either gatewayIp or gatewayHostname should be provided when using gateway. |
+| `gatewayHostname` | string | `""` | Hostname of the gateway. Either gatewayIp or gatewayHostname should be provided when using gateway. |
+| `gatewayAPIVersion` | string | `"gateway.networking.k8s.io/v1"` | API version of the gateway. Supported values: `gateway.networking.k8s.io/v1`, `networking.istio.io/v1alpha3` |
+
+### Storage Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `storageS3UsePathStyle` | bool | `false` | Use path-style S3 URLs instead of virtual-hosted-style URLs |
+
+### Other Advanced Features
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enableAnyscaleRayHeadNodePDB` | bool | `true` | Enable PodDisruptionBudget for head nodes |
+| `enableKarpenterSupport` | bool | `false` | Enable Karpenter support |
+| `enableZoneNodeSelector` | bool | `false` | Enable zone-based node selection |
+| `operatorExcludeComponentVerification` | array | `[]` | Components to skip during startup verification |
+
+
+## Installation
+
+For detailed installation instructions, please refer to the [Anyscale Operator Documentation](https://docs.anyscale.com/administration/cloud-deployment/kubernetes/).

--- a/charts/anyscale-operator/templates/_helpers.tpl
+++ b/charts/anyscale-operator/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Validate controlPlaneURL to ensure it doesn't end with a trailing slash
+*/}}
+{{- define "anyscale-operator.validateControlPlaneURL" -}}
+{{- $url := .Values.controlPlaneURL | default "https://console.anyscale.com" -}}
+{{- if hasSuffix "/" $url -}}
+{{- fail (printf "controlPlaneURL must not end with a trailing slash. Current value: %s" $url) -}}
+{{- end -}}
+{{- $url -}}
+{{- end -}}

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -15,7 +15,9 @@ data:
     ########################################
     # Service Account Support
     ########################################
+    # Apply service account patch only to pods that don't have IAM mapping
     - kind: Pod
+      selector: "!{{ .Values.iamMappingAnnotation }}"
       patch:
         - op: add
           path: /spec/serviceAccountName
@@ -123,6 +125,23 @@ data:
         - op: add
           path: /spec/nodeSelector/cloud.google.com~1gke-spot
           value: "true"
+    - kind: Pod
+      selector: "anyscale.com/market-type in (ON_DEMAND)"
+      patch:
+        - op: add
+          path: /spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
+          value:
+            matchExpressions:
+              - key: cloud.google.com/gke-spot
+                operator: DoesNotExist
+        - op: add
+          path: /spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
+          value:
+            matchExpressions:
+              - key: cloud.google.com/gke-spot
+                operator: NotIn
+                values:
+                  - "true"
     {{- end }}
 
     {{- if .Values.enableZoneNodeSelector }}

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       {{- if eq .Values.cloudProvider "azure" }}
       annotations:
         azure.workload.identity/inject-proxy-sidecar: "true"
+        azure.workload.identity/proxy-sidecar-port: {{ .Values.azureWorkloadIdentityProxyPort | default 10000 | quote }}
       {{- end }}
     spec:
       serviceAccount: anyscale-operator
@@ -34,9 +35,13 @@ spec:
       affinity:
 {{ toYaml .Values.operatorNodeSelection.affinity | indent 8 }}
       {{- end }}
+      {{- if .Values.operatorNodeSelection.tolerations }}
+      tolerations:
+{{ toYaml .Values.operatorNodeSelection.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: operator
-        image: "{{ required "operatorImage is required" .Values.operatorImage }}"
+        image: '{{ required "operatorImage is required" .Values.operatorImage }}'
         imagePullPolicy: {{ .Values.operatorImagePullPolicy | default "IfNotPresent" }}
         command: ["/app/go/infra/kubernetes_manager/kubernetes_manager"]
         args:
@@ -44,21 +49,37 @@ spec:
         - --log-file=/tmp/anyscale/logs/operator.log
         - start
         - --cloud-deployment-id={{ required "cloudDeploymentId is required" .Values.cloudDeploymentId }}
-        - --control-plane-url={{ .Values.controlPlaneURL | default "https://console.anyscale.com" }}
+        - --control-plane-url={{ include "anyscale-operator.validateControlPlaneURL" . }}
         - --cloud-provider={{ .Values.cloudProvider }}
-        {{ if not .Values.anyscaleCliToken }}
+        {{- if .Values.unscheduledPodReaperTerminationThreshold }}
+        - --unscheduled-pod-reaper-termination-threshold={{ .Values.unscheduledPodReaperTerminationThreshold }}
+        {{- end }}
+        {{- if .Values.unscheduledPodReaperReconcileInterval }}
+        - --unscheduled-pod-reaper-reconcile-interval={{ .Values.unscheduledPodReaperReconcileInterval }}
+        {{- end }}
+        {{- if .Values.kubernetesClientRateLimiterQPS }}
+        - --kubernetes-client-rate-limiter-qps={{ .Values.kubernetesClientRateLimiterQPS }}
+        {{- end }}
+        {{- if .Values.kubernetesClientRateLimiterBurst }}
+        - --kubernetes-client-rate-limiter-burst={{ .Values.kubernetesClientRateLimiterBurst }}
+        {{- end }}
+        {{- if not .Values.anyscaleCliToken }}
         - --region={{ required "region is required for operator registration if anyscaleCliToken is not provided & cloud-native bootstrap scheme is used; must be set to the cloud provider region of this Kubernetes cluster" .Values.region }}
-        {{ end }}
+        {{- end }}
         - --patch-config-path=/tmp/config/patches.yaml
         {{- if .Values.enableGateway }}
         - --enable-gateway=true
         - --gateway-name={{ .Values.gatewayName }}
         - --gateway-hostname={{ .Values.gatewayHostname }}
         - --gateway-ip={{ .Values.gatewayIp }}
+        - --gateway-api-version={{ .Values.gatewayAPIVersion }}
         {{- end }}
         - --system-logs-ingress-proxy-port=3100
         - --system-metrics-ingress-proxy-port=3101
         - --vector-enrichment-table-path=/tmp/config/vector/runtime_metadata.csv
+        {{- if .Values.kubeConfigPath }}
+        - --kube-config={{ .Values.kubeConfigPath }}
+        {{- end }}
         {{- if gt (int .Values.operatorReplicas) 1 }}
         - --enable-leader-election=true
         - --leader-election-lease-namespace={{ .Release.Namespace }}
@@ -69,9 +90,16 @@ spec:
         - --exclude-component-verification={{ . }}
         {{- end }}
         {{- end }}
+        {{- if .Values.enableStatusReporting }}
+        - --enable-status-reporting=true
+        {{- end }}
         resources:
 {{ toYaml .Values.operatorResources.operator | indent 10 }}
         env:
+        {{ if default false .Values.storageS3UsePathStyle }}
+        - name: ANYSCALE_S3_USE_PATH_STYLE
+          value: "true"
+        {{ end }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/anyscale-operator/templates/role.yaml
+++ b/charts/anyscale-operator/templates/role.yaml
@@ -16,8 +16,13 @@ rules:
   resources: ["ingresses"]
   verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 {{- if .Values.enableGateway }}
+{{- if eq .Values.gatewayAPIVersion "networking.istio.io/v1alpha3" }}
+- apiGroups: ["networking.istio.io"]
+  resources: ["virtualservices"]
+{{- else }}
 - apiGroups: ["gateway.networking.k8s.io"]
   resources: ["httproutes"]
+{{- end }}
   verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 {{- end }}
 {{- if gt (int .Values.operatorReplicas) 1 }}

--- a/charts/anyscale-operator/templates/validating_webhook.yaml
+++ b/charts/anyscale-operator/templates/validating_webhook.yaml
@@ -16,7 +16,7 @@ webhooks:
     scope: Namespaced
     operations: ["CREATE", "UPDATE"]
   clientConfig:
-    url: {{or .Values.controlPlaneURL "https://console.anyscale.com"}}/api/v2/kubernetes_manager/admission/{{ .Values.cloudDeploymentId }}
+    url: {{ include "anyscale-operator.validateControlPlaneURL" . }}/api/v2/kubernetes_manager/admission/{{ .Values.cloudDeploymentId }}
   sideEffects: None
   timeoutSeconds: 30
   # We are starting with hard-failing here; this can be changed to soft-failing if issues arise (e.g. control plane availability).

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-bbdd5c6b3eb955e144f0a15f6f5366a30d2a8012"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-3fa6f421ed6e4209e5f3c4b62a87c2d2159d5129"
 
 # operatorIamIdentity specifies the IAM identity from the cloud provider to bind to the Anyscale Operator.
 # This is only supported on AWS/GCP. For AWS, this should be the ARN of the IAM role. For GCP, this should be the email of the
@@ -40,10 +40,15 @@ operatorResources:
 operatorReplicas: 1
 
 # operatorExcludeComponentVerification allows specifying components to skip verification for during the
-# operator startup sequence.
+# operator startup sequence and status checks
 #
 # Valid values are:
 #  - STORAGE_BUCKET
+#  - KUBERNETES_VERSION
+#  - GATEWAY_RESOURCES
+#  - CLOUD_RESOURCES
+#  - IAM_IDENTITY
+#  - KUBERNETES_PERMISSIONS
 #
 # By default, all components will be verified during the operator startup sequence.
 operatorExcludeComponentVerification: []
@@ -56,6 +61,8 @@ operatorNodeSelection:
   nodeSelector: {}
   # affinity allows for more complex node selection rules
   affinity: {}
+  # tolerations allow the operator pod to schedule on nodes with matching taints
+  tolerations: []
 
 # defaultInstanceTypes provides a list of default Pod shapes that can be
 # used in Anyscale workloads (abstracted as virtual "instance types").
@@ -157,6 +164,9 @@ acceleratorNodeSelector: ""
 # If set, this service account will be assigned to Pods running Anyscale workloads.
 workloadServiceAccountName: ""
 
+# IAM mapping annotation key used to identify pods that use IAM mapping
+iamMappingAnnotation: "anyscale.com/iam-mapping"
+
 # Default tolerances - these match the Anyscale recommended NodeGroup configurations,
 # including those provided by the Anyscale Cloud Foundations Terraform Modules
 workloadDefaultTolerances:
@@ -214,3 +224,36 @@ gatewayIp: ""
 # gatewayHostname specifies the hostname of the gateway.
 # This is used for routing traffic through the gateway.
 gatewayHostname: ""
+
+# gatewayAPIVersion specifies the API version of the gateway.
+# This is used to identify the gateway resource in the k8s cluster.
+# Supported values are "gateway.networking.k8s.io/v1" and "networking.istio.io/v1alpha3".
+gatewayAPIVersion: "gateway.networking.k8s.io/v1"
+
+# Sets https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property
+storageS3UsePathStyle: false
+
+# string, kube-config
+# The path to the kubeconfig file to use for the Kubernetes client.
+# If not provided, in-cluster configuration will be used.
+kubeConfigPath: ""
+
+# duration, unscheduled-pod-reaper-reconcile-interval, default: 1m
+# The interval at which the unscheduled pod reaper should reconcile.
+unscheduledPodReaperReconcileInterval:
+
+# duration, unscheduled-pod-reaper-termination-threshold, default: 10m
+# The threshold after which an unscheduled Pod should be considered leaked + terminated.
+unscheduledPodReaperTerminationThreshold:
+
+# float32, kubernetes-client-rate-limiter-qps, default: 1000
+# The QPS rate limit for the Kubernetes client. Recommended to set to large values (e.g. 1000) to support large workloads.
+kubernetesClientRateLimiterQPS: 1000
+
+# int, kubernetes-client-rate-limiter-burst, default: 2000
+# The burst rate limit for the Kubernetes client. Recommended to set to large values (e.g. 2000) to support large workloads.
+kubernetesClientRateLimiterBurst: 2000
+
+# bool, enable-status-reporting, default: true
+# Whether to enable status reporting to the Anyscale Control Plane.
+enableStatusReporting: true


### PR DESCRIPTION
# Release `0.6.0`
This release adds Istio Gateway support, operator status reporting, support for customizing service accounts for workloads, observability improvements for image pulling, and node toleration for the operator pods.

This release is backward-compatible and is recommended for all users. See `New Values` for information on how to disable health checks and enable Istio Gateway support.

## New Values

### Operator Status Reporting
The operator can now validate whether it has been configured correctly and report this information back to the control plane. This can be useful for debugging operator setup issues, as well as receiving automated alerts if the operator begins status reporting but then disconnects. In order to enable this feature set `enableStatusReporting: true`. Older versions of the operator will show up as unspecified in the UI and will not cause disconnect alert emails to fire to support backwards compatibility.

### Istio Gateway Support
The operator can now create Istio [VirtualServices](https://istio.io/latest/docs/reference/config/networking/virtual-service/) to route traffic from your Gateway to your Serve workloads. To enable this set `gatewayAPIVersion:: networking.istio.io/v1alpha3`


Name | Description | Default
-- | -- | --
gatewayAPIVersion | Controls what API will be used for Gateway support. Supported values are "gateway.networking.k8s.io/v1" and "networking.istio.io/v1alpha3". | "gateway.networking.k8s.io/v1" | ""
enableStatusReporting | Controls whether the operator will perform health checks and report its status to the control plane | true


## Updated Values

### Operator Status Reporting
The `operatorExcludeComponentVerification` field can now be used to determine what health checks to skip during status reporting by passing their name as a list. The list of all checks currently run is:
- **STORAGE_BUCKET**: operator has permission to access object storage
- **KUBERNETES_PERMISSIONS**: operator has correct Kubernetes RBAC permissions
- **KUBERNETES_VERSION**: cluster version is within tested range, throws a warning if not
- **GATEWAY_RESOURCES**: if gateway is enabled, ensures the related CRDs are present on the cluster
- **IAM_IDENTITY**: ensures the IAM identity of the operator matches the cloud's configuration (ex: AWS IAM role, GCP service account, Azure Workload Identity)

### Operator Node Toleration
The `operatorNodeSelection.tolerations` field can now be used to specify tolerations to add onto the operator pod to help with scheduling. 

Name | Description | Default
-- | -- | --
operatorExcludeComponentVerification | A list of health check names to be skipped. Supported names are STORAGE_BUCKET, KUBERNETES_VERSION, GATEWAY_RESOURCES, CLOUD_RESOURCES, IAM_IDENTITY, KUBERNETES_PERMISSIONS | [] | ""
operatorNodeSelection.tolerations | YAML list of tolerations to be applied onto the operator pod | []

## Fixes

### Azure Workload Identity Proxy + Anyscale Service Compatibility
AKS Workload Identity proxy now uses port tcp/10000 instead of the default tcp/8000 which may overlap with Anyscale Service listeners

## Other

### Service Account Workloads
This change ensures that when IAM mapping is enabled via cloud config update API for Kubernetes clouds, the default service account assignment is skipped for pods that already have IAM mapping configured

### Surface Image Pull Events in UI
To give users greater visibility into cluster startup, we now surface head node image “pulling” and “pulled” events from the Anyscale Operator in the Console UI. This helps users quickly see when the head node image download starts and completes, making it easier to monitor progress and detect potential startup delays.

## Kubernetes Operator Updates

### Updated the Kubernetes Operator Image
- Support for new features

**Full Changelog**: https://github.com/anyscale/helm-charts/compare/anyscale-operator-0.5.3...anyscale-operator-0.6.0

This release is backward compatible and recommended for all users.