### PR TITLE
Anyscale Operator 0.6.1

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.6.0
+version: 0.6.1

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-3fa6f421ed6e4209e5f3c4b62a87c2d2159d5129"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-57e6f4edef180e37fb07f4d2b2442ad9b02eb16a"
 
 # operatorIamIdentity specifies the IAM identity from the cloud provider to bind to the Anyscale Operator.
 # This is only supported on AWS/GCP. For AWS, this should be the ARN of the IAM role. For GCP, this should be the email of the


### PR DESCRIPTION
# Release `0.6.1`

Bugfix for handling `Values.gatewayAPIVersion` in operator status checks where we would expect Istio Gateway CRDs to be installed when using `"gateway.networking.k8s.io/v1"`

This release is backwards compatible and recommended for all users.