### PR TITLE
Anyscale Operator 0.6.3

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.6.2
+version: 0.6.3

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -170,14 +170,11 @@ data:
       selector: "!anyscale.com/accelerator-type"
       patch:
         - op: add
-          path: /spec/affinity
+          path: /spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
           value:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                    - key: "nvidia.com/gpu.count"
-                      operator: DoesNotExist
+            matchExpressions:
+              - key: "nvidia.com/gpu.count"
+                operator: DoesNotExist
     {{- range $key, $value := .Values.supportedAccelerators.aws }}
     - kind: Pod
       selector: "anyscale.com/accelerator-type in ({{ $key }})"

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-57e6f4edef180e37fb07f4d2b2442ad9b02eb16a"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-1449ce2282c302f4da4378daa67c6073d78686a7"
 
 # operatorIamIdentity specifies the IAM identity from the cloud provider to bind to the Anyscale Operator.
 # This is only supported on AWS/GCP. For AWS, this should be the ARN of the IAM role. For GCP, this should be the email of the


### PR DESCRIPTION
### Summary

- Add the support for abfss protocol support

**Context**: This stands for Azure Blob File System Secure and is used specifically with Azure Data Lake Storage Gen2.
**Usage**: It is the actual protocol used by Spark, Hadoop, and other big data tools to securely access files in ADLS Gen2.
**Security**: The abfss:// scheme ensures secure communication (HTTPS) and is preferred over abfs://, which is non-secure.
**Example**: abfss://[myfilesystem@myaccount.dfs.core.windows.net/myfolder/myfile.csv](http://myfilesystem@myaccount.dfs.core.windows.net/myfolder/myfile.csv)

- Gateway canary bug fix

There is some bug with tracking canary state when using the gateway apis, which causes the canary service to become untracked while canary-exists: true remains on the primary HTTP Route. As a result, after a rolling upgrade we will continue to have a route that references the canary service, but its weight will be 0 so nothing ever gets routed there. When the reconciler garbage collections the canary service it will still be present on the HTTP Route, so for a brief period of time this route will be referencing a service that does not exist which causes the gateway controller to throw 500s. This is transient because once the canary service is garbage collected canary-exists will be set to false again and the reference to the canary service will be removed, causing the HTTP Route to be valid again.

We changes our HTTPRoute/VirtualService spec generation to ignore creating a backend ref when the weight is 0 to avoid these invalid reference errors. Since weight being 0 is effectively the same as the route not being specified this has no functional differences, but prevents this garbage collection scenario from causing temporary gateway downtime