### PR TITLE
ad configurable operator imagePullSecrets

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.6.4
+version: 0.6.5

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       tolerations:
 {{ toYaml .Values.operatorNodeSelection.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.operatorImagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.operatorImagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
       - name: operator
         image: '{{ required "operatorImage is required" .Values.operatorImage }}'

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,6 +56,9 @@ operatorReplicas: 1
 # By default, all components will be verified during the operator startup sequence.
 operatorExcludeComponentVerification: []
 
+# operatorImagePullSecrets allows configuring imagePullSecrets to enable pulling the operator image through a private docker proxy.
+operatorImagePullSecrets: []
+
 # operatorNodeSelection allows configuring where the Anyscale Operator pods are scheduled.
 # Either nodeSelector or affinity can be specified
 # If both are specified, nodeSelector takes precedence.


### PR DESCRIPTION
This allows for specifying imagePullSecrets on the operator deployment. This will allow users to use a private docker proxy to load the operator image through, which is a common security requirement in some orgs