### PR TITLE
Anyscale Operator 0.7.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.6.5
+version: 0.7.0

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -19,6 +19,7 @@ The following are required values for the Anyscale Operator.
 | `region` | string | `""` | Cloud region for deployment |
 | `anyscaleCliToken` | string | `""` | Anyscale CLI token for control plane authentication. Falls back to cloud provider identity if not set. This is required for Azure and Generic deployments. |
 | `operatorIamIdentity` | string | `""` | Cloud provider IAM identity (AWS role ARN , GCP service account email, Azure identity) |
+| `operatorImage` | string | `""` | Docker image to use for the Anyscale Operator. Updated with helm releases. Anyscale support may provide preview version of image for debugging. |
 
 ## Advanced Configuration
 
@@ -97,7 +98,6 @@ For advanced usage consult with Anyscale support.
 | `operatorImagePullPolicy` | string | `"IfNotPresent"` | imagePullPolicy for the Anyscale Operator. |
 | `vectorImage` | string | `"timberio/vector:0.40.0-debian"` | Docker image to use for the Vector sidecar. |
 | `vectorImagePullPolicy` | string | `"IfNotPresent"` | imagePullPolicy for the Vector sidecar. |
-
 
 ## Installation
 

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -219,7 +219,7 @@ data:
     {{- $additionalInstanceTypesCopy := deepCopy (default dict .Values.additionalInstanceTypes) }}
     {{- $instanceTypes := merge $defaultInstanceTypesCopy $additionalInstanceTypesCopy }}
     {{- range $instanceType, $config := $instanceTypes }}
-      {{- if $config.nodeSelector }}
+      {{- if or $config.nodeSelector $config.tolerations }}
     - kind: Pod
       selector: "anyscale.com/instance-type in ({{ $instanceType }})"
       patch:
@@ -227,6 +227,17 @@ data:
         - op: add
           path: /spec/nodeSelector/{{ $key | replace "/" "~1" }}
           value: "{{ $value }}"
+        {{- end }}
+        {{- range $toleration := $config.tolerations }}
+        - op: add
+          path: /spec/tolerations/-
+          value:
+            key: {{ quote $toleration.key }}
+            operator: "{{ if $toleration.value }}Equal{{- else }}Exists{{- end }}"
+            {{- if $toleration.value }}
+            value: {{ quote $toleration.value }}
+            {{- end }}
+            effect: {{ quote $toleration.effect | default "NoSchedule" }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -97,6 +97,7 @@ spec:
         {{- if .Values.enableStatusReporting }}
         - --enable-status-reporting=true
         {{- end }}
+        - --operator-version={{ .Chart.Version }}
         resources:
 {{ toYaml .Values.operatorResources.operator | indent 10 }}
         env:

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -13,7 +13,7 @@ anyscaleCliToken: ""
 region: ""
 
 # operatorImage specifies the Docker image to use for the Anyscale Operator.
-operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-1449ce2282c302f4da4378daa67c6073d78686a7"
+operatorImage: "public.ecr.aws/v0b8w7e3/anyscale/kubernetes_manager:ci-59b02256716cb8cb6ddb281ba00dd9a12ce24a6f"
 
 # vectorImage specifies the Docker image to use for the Vector sidecar.
 vectorImage: "timberio/vector:0.40.0-debian"
@@ -73,8 +73,8 @@ operatorNodeSelection:
 # defaultInstanceTypes provides a list of default Pod shapes that can be
 # used in Anyscale workloads (abstracted as virtual "instance types").
 #
-# Node selectors that apply specifically to these instance types can be
-# placed directly under each instance type under the `nodeSelector` key.
+# Node selectors and tolerations that apply specifically to these instance types can be
+# placed directly under each instance type under the `nodeSelector` and `tolerations` keys.
 defaultInstanceTypes:
   2CPU-8GB:
     resources:
@@ -109,6 +109,10 @@ defaultInstanceTypes:
   #     cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
   #     cloud.google.com/gke-tpu-topology: 2x2
   #     cloud.google.com/gke-spot: "true"
+  #   tolerations:
+  #     - key: "custom-taint"
+  #       operator: "Exists"
+  #       effect: "NoSchedule"
   # 8CPU-16GB-TPU-V5E-4x4-MULTIHOST:
   #   resources:
   #     CPU: 8


### PR DESCRIPTION
# Release `0.7.0`
This release adds logic to ship additional operator status details back to the Anyscale platform for better observability and support for customizing tolerations that will be applied to pods for an instance type.

This release is backward-compatible and is recommended for all users. See `Updated Values` for information on how to configure tolerations for instance types.

## Updated Values

### Instance Type Toleration
All values fields that define instance types now support a nested `tolerations` key to specify what tolerations to apply for pods of that instance type. This includes `defaultInstanceTypes` and `additionalInstanceTypes`. For example, you can now define an instance type like so to ensure all pods tolerate `custom-taint`:

```
8CPU-32GB-1xT4:
  resources:
    CPU: 8
    GPU: 1
    memory: 32Gi
    'accelerator_type:T4': 1
  tolerations:
    - key: "custom-taint"
      operator: "Exists"
      effect: "NoSchedule"
```

### Updated the Kubernetes Operator Image
- Support for new features

**Full Changelog**: https://github.com/anyscale/helm-charts/compare/anyscale-operator-0.6.5...anyscale-operator-0.7.0

This release is backward compatible and recommended for all users.