### PR TITLE
Anyscale Operator v0.8.1

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.8.0
+version: 0.8.1
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/templates/_helpers.tpl
+++ b/charts/anyscale-operator/templates/_helpers.tpl
@@ -8,3 +8,10 @@ Validate controlPlaneURL to ensure it doesn't end with a trailing slash
 {{- end -}}
 {{- $url -}}
 {{- end -}}
+
+{{/*
+Converts string passed in into a json pointer
+*/}}
+{{- define "anyscale-operator.jsonPointer" -}}
+{{- . | replace "~" "~0" | replace "/" "~1" -}}
+{{- end -}}

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -181,7 +181,7 @@ data:
       patch:
         - op: add
           {{- if $.Values.acceleratorNodeSelector }}
-          path: /spec/nodeSelector/{{ $.Values.acceleratorNodeSelector }}
+          path: /spec/nodeSelector/{{ include "anyscale-operator.jsonPointer" $.Values.acceleratorNodeSelector }}
           {{- else }}
           path: /spec/nodeSelector/nvidia.com~1gpu.product
           {{- end }}
@@ -194,7 +194,7 @@ data:
       patch:
         - op: add
           {{- if $.Values.acceleratorNodeSelector }}
-          path: /spec/nodeSelector/{{ $.Values.acceleratorNodeSelector }}
+          path: /spec/nodeSelector/{{ include "anyscale-operator.jsonPointer" $.Values.acceleratorNodeSelector }}
           {{- else }}
           path: /spec/nodeSelector/cloud.google.com~1gke-accelerator
           {{- end }}
@@ -225,7 +225,7 @@ data:
       patch:
         {{- range $key, $value := $config.nodeSelector }}
         - op: add
-          path: /spec/nodeSelector/{{ $key | replace "/" "~1" }}
+          path: /spec/nodeSelector/{{ include "anyscale-operator.jsonPointer" $key }}
           value: "{{ $value }}"
         {{- end }}
         {{- range $toleration := $config.tolerations }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -305,7 +305,7 @@ ingress-nginx:
       # Required for authorization snippets to work with Anyscale Services.
       annotations-risk-level: "Critical"
     autoscaling:
-      enabled: true
+      enabled: false
 
     ingressClassResource:
       # The name of the ingress class resource to use. Useful to have this set to something other than "nginx" if you want to deploy multiple isolated ingress controllers within the same cluster.


### PR DESCRIPTION
# Release `0.8.1`
This release adds minor bugfixes to chart templating logic. This release is backward-compatible and is recommended for all users. 

## Bugfixes
- add utility function to convert strings into JSON pointers for patching
- fix bug where acceleratorNodeSelector was not being correctly converted into a JSON pointer, causing issues if the value contained `/` (such as for `karpenter.k8s.aws/instance-gpu-name`)
- disable nginx autoscaling by default
