### PR TITLE
Anyscale Operator 0.9.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 0.8.1
+version: 0.9.0
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/templates/_helpers.tpl
+++ b/charts/anyscale-operator/templates/_helpers.tpl
@@ -9,6 +9,53 @@ Validate controlPlaneURL to ensure it doesn't end with a trailing slash
 {{- $url -}}
 {{- end -}}
 
+{{- define "anyscale-operator.aws_credentials" -}}
+[default]
+aws_access_key_id = {{ required "A valid .Values.aws.credentialSecret.accessKeyId is required if .Values.aws.credentialSecret.create is true" .Values.aws.credentialSecret.accessKeyId }}
+aws_secret_access_key = {{ required "A valid .Values.aws.credentialSecret.secretAccessKey is required if .Values.aws.credentialSecret.create is true" .Values.aws.credentialSecret.secretAccessKey }}
+{{- end }}
+
+{{- define "anyscale-operator.aws_config" -}}
+[default]
+region = {{ .Values.region }}
+{{- if .Values.aws.credentialSecret.endpointUrl }}
+endpoint_url = {{ .Values.aws.credentialSecret.endpointUrl }}
+{{- end }}
+{{- end }}
+
+{{- define "anyscale-operator.aws_credential_mount_patch" -}}
+- kind: Pod
+  patch:
+    - op: add
+      path: /spec/volumes/-
+      value:
+        name: aws-creds
+        secret:
+          secretName: {{ .Values.aws.credentialSecret.name }}
+    - op: add
+      path: /spec/containers/0/volumeMounts/-  # 0 = ray
+      value:
+        name: aws-creds
+        mountPath: {{ .Values.aws.credentialSecret.podMountPath }}
+        readOnly: true
+    - op: add
+      path: /spec/containers/2/volumeMounts/-  # 2 = anyscaled
+      value:
+        name: aws-creds
+        mountPath: {{ .Values.aws.credentialSecret.podMountPath }}
+        readOnly: true
+    - op: add
+      path: /spec/containers/0/env/-
+      value:
+        name: AWS_SHARED_CREDENTIALS_FILE
+        value: {{ .Values.aws.credentialSecret.podMountPath }}/credentials
+    - op: add
+      path: /spec/containers/2/env/-
+      value:
+        name: AWS_SHARED_CREDENTIALS_FILE
+        value: {{ .Values.aws.credentialSecret.podMountPath }}/credentials
+{{- end }}
+
 {{/*
 Converts string passed in into a json pointer
 */}}

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -145,6 +145,41 @@ data:
                 operator: NotIn
                 values:
                   - "true"
+    {{- else if eq .Values.cloudProvider "azure" }}
+    - kind: Pod
+      selector: "anyscale.com/market-type in (SPOT)"
+      patch:
+        - op: add
+          path: /spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
+          value:
+            matchExpressions:
+              - key: kubernetes.azure.com/scalesetpriority
+                operator: In
+                values:
+                  - "spot"
+        - op: add
+          path: /spec/tolerations/-
+          value:
+            key: kubernetes.azure.com/scalesetpriority
+            effect: NoSchedule
+            value: "spot"
+    - kind: Pod
+      selector: "anyscale.com/market-type in (ON_DEMAND)"
+      patch:
+        - op: add
+          path: /spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
+          value:
+            matchExpressions:
+              - key: kubernetes.azure.com/scalesetpriority
+                operator: NotIn
+                values:
+                  - "spot"
+        - op: add
+          path: /spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/-
+          value:
+            matchExpressions:
+              - key: kubernetes.azure.com/scalesetpriority
+                operator: DoesNotExist
     {{- end }}
 
     {{- if .Values.enableZoneNodeSelector }}
@@ -267,6 +302,12 @@ data:
           value: {{ index .Values "ingress-nginx" "controller" "ingressClassResource" "name" }}
     {{- end }}
 
+    {{- if and .Values.aws.credentialSecret.enabled}}
+    ########################################
+    # AWS Credential Secret
+    ########################################
+    {{- include "anyscale-operator.aws_credential_mount_patch" . | nindent 4 }}
+    {{- end }}
     ########################################
     # Additional Patches
     ########################################

--- a/charts/anyscale-operator/templates/credentials.yaml
+++ b/charts/anyscale-operator/templates/credentials.yaml
@@ -1,0 +1,15 @@
+{{if and .Values.aws.credentialSecret.enabled .Values.aws.credentialSecret.create}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.aws.credentialSecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  credentials: {{ include "anyscale-operator.aws_credentials" . | b64enc | quote }}
+  config: {{ include "anyscale-operator.aws_config" . | b64enc | quote }}
+{{end}}

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -123,6 +123,11 @@ spec:
             mountPath: /tmp/config
           - name: vector-config
             mountPath: /tmp/config/vector/
+          {{- if and .Values.aws.credentialSecret.enabled}}
+          - mountPath: {{ required "A valid .Values.aws.credentialSecret.operatorMountPath is required if .Values.aws.credentialSecret.enabled is true" .Values.aws.credentialSecret.operatorMountPath }}
+            name: aws-creds
+            readOnly: true
+          {{- end }}
       - name: vector
         image: '{{ required "vectorImage is required" .Values.vectorImage }}'
         imagePullPolicy: {{ .Values.vectorImagePullPolicy | default "IfNotPresent" }}
@@ -170,3 +175,8 @@ spec:
           emptyDir: {}
         - name: vector-config
           emptyDir: {}
+        {{- if and .Values.aws.credentialSecret.enabled}}
+        - name: aws-creds
+          secret:
+            secretName: {{ required "A valid .Values.aws.credentialSecret.name is required if .Values.aws.credentialSecret.enabled is true" .Values.aws.credentialSecret.name }}
+        {{- end }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -310,3 +310,31 @@ ingress-nginx:
     ingressClassResource:
       # The name of the ingress class resource to use. Useful to have this set to something other than "nginx" if you want to deploy multiple isolated ingress controllers within the same cluster.
       name: anyscale-nginx
+
+# AWS related values.
+aws:
+  # Support for using a Kubernetes secret to mount AWS credential and config files into the Anyscale Operator and pods it manages.
+  # NOTE: this is not encouraged and should only be used if workload identity federation is not available.
+  credentialSecret:
+    # Whether to mount the AWS credential secret into the Anyscale Operator and pods it manages.
+    enabled: false
+
+    # The name of the credential secret
+    name: anyscale-aws-credentials
+
+    # Whether to create the credential secret. If false, the secret must already exist with the name specified in 'name' above.
+    # and match the format defined in the AWS credential secret template (templates/credentials.yaml)
+    create: false
+
+    # The access key ID of the AWS credential secret.
+    accessKeyId: ""
+    # The secret access key of the AWS credential secret.
+    secretAccessKey: ""
+    # The endpoint value to be stored in the AWS config file, optional.
+    endpointUrl: ""
+
+    # The mount path for the AWS credential secret in the Anyscale Operator pod
+    operatorMountPath: /root/.aws
+
+    # The mount path for the AWS credential secret in the workload pods
+    podMountPath: /tmp/.aws


### PR DESCRIPTION
# Release `0.9.0`
This release adds an optional feature to create and mount hard-coded AWS credentials onto the operator pod and pods it manages. This is not a recommended practice and should only be used when [workload based access](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html) is not possible. This release also contains patches to enable market type support on AKS.

This release is backward-compatible and is recommended for all users. See `New Values` for information on how to configure AWS credential secret support.

## New Values
### AWS Credential Secret
You can now mount a Kubernetes Secret containing AWS credential and config file contents into the operator pod and the pods it manages.

Name | Description | Default
-- | -- | --
aws.credentialSecret.enabled | Whether to enable AWS credential secret support. If true, the secret referenced by `aws.credentialSecret.name` will be mounted into the operator pod and all pods it manages. | false | ""
aws.credentialSecret.name | The name of the secret storing the credential and config file content. See `templates/credentials.yaml` for the expected format | anyscale-aws-credentials | ""
aws.credentialSecret.create | Whether to create the credential secret as part of the chart using credentials passed into the values file. Set to false if you would like to have the operator use an externally created secret and set `aws.credentialSecret.name` to that secret's name. | false | ""
aws.credentialSecret.accessKeyId | The AWS Access Key ID stored in the credential secret created if `aws.credentialSecret.create` is set to `true`| "" | ""
aws.credentialSecret.secretAccessKey | The AWS Secret Access Key stored in the credential secret created if `aws.credentialSecret.create` is set to `true` | "" | ""
aws.credentialSecret.endpointUrl | The endpoint url to store in the config section in the credential secret created if `aws.credentialSecret.create` is set to `true`. If unset, defaults to `region` | "" | ""
operatorMountPath | The path to mount the credential secret as a volume in the operator. | /root/.aws | ""
podMountPath | The path to mount the credential secret as a volume in the pods the operator manages. | /tmp/.aws | "" 


## Other
### AKS Market Place Patches
If `cloudProvider` is set to `azure` we now correctly generate patches to add nodeSelector and nodeAffinity to place spot and on-demand workloads.

**Full Changelog**: https://github.com/anyscale/helm-charts/compare/anyscale-operator-0.8.1...anyscale-operator-0.9.0

This release is backward compatible and recommended for all users.