### PR TITLE
Anyscale Operator 1.5.1

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 1.5.0
+version: 1.5.1
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -134,7 +134,7 @@ For advanced usage consult with Anyscale support.
 |-----------|------|---------|-------------|
 | `operator.container.image.registry` | string | `"us-docker.pkg.dev"` | Operator container image registry |
 | `operator.container.image.image` | string | `"anyscale-artifacts/public/kubernetes_manager"` | Operator container image name |
-| `operator.container.image.tag` | string | `ci-1c50ff468e55cdf634c7153455d6c0f02550c952` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
+| `operator.container.image.tag` | string | `ci-268c63e5e7283355876c20a6a4bfad93fa4e736a` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
 | `operator.container.resources.requests.memory` | string | `"512Mi"` | Operator container memory request |
 | `operator.container.resources.requests.cpu` | int | `1` | Operator container CPU request |
 | `operator.container.resources.limits.memory` | string | `"2Gi"` | Operator container memory limit |
@@ -194,4 +194,4 @@ For advanced usage consult with Anyscale support.
 
 ## Installation
 
-For detailed installation instructions, please refer to the [Anyscale Operator Documentation](https://docs.anyscale.com/administration/cloud-deployment/kubernetes/).
+For detailed installation instructions, please refer to the [Anyscale Operator Documentation](https://docs.anyscale.com/admin/cloud/kubernetes).

--- a/charts/anyscale-operator/templates/_helpers.tpl
+++ b/charts/anyscale-operator/templates/_helpers.tpl
@@ -9,6 +9,37 @@ Validate controlPlaneURL to ensure it doesn't end with a trailing slash
 {{- $url -}}
 {{- end -}}
 
+{{- define "anyscale-operator.usePathStyle" -}}
+{{- if or .Values.global.aws.s3.usePathStyle (eq (.Values.credentialMount.aws.createSecret.addressingStyle | default "") "path") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "anyscale-operator.aws_specific_patches" -}}
+{{- $headContainerIndices := list 0 1 2 5 -}}{{/* ray, vector, anyscaled, activity-probe */}}
+{{- $workerContainerIndices := list 0 1 2 3 -}}{{/* ray, vector, anyscaled, activity-probe */}}
+{{- if include "anyscale-operator.usePathStyle" $ }}
+- kind: Pod
+  selector: "anyscale.com/ray-node-type in (head)"
+  patch:
+    {{- range $headContainerIndices }}
+    - op: add
+      path: /spec/containers/{{ . }}/env/-
+      value:
+        name: ANYSCALE_S3_USE_PATH_STYLE
+        value: "true"
+    {{- end }}
+- kind: Pod
+  selector: "anyscale.com/ray-node-type in (worker)"
+  patch:
+    {{- range $workerContainerIndices }}
+    - op: add
+      path: /spec/containers/{{ . }}/env/-
+      value:
+        name: ANYSCALE_S3_USE_PATH_STYLE
+        value: "true"
+    {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "anyscale-operator.aws_credentials" -}}
 [default]
 aws_access_key_id = {{ required "A valid .Values.credentialMount.aws.createSecret.accessKeyId is required if .Values.credentialMount.aws.createSecret.create is true" .Values.credentialMount.aws.createSecret.accessKeyId }}

--- a/charts/anyscale-operator/templates/_rbac_rules.tpl
+++ b/charts/anyscale-operator/templates/_rbac_rules.tpl
@@ -34,12 +34,4 @@ The conditional logic for enableCrossNamespaceResourceManagement is handled in t
     resources: ["workloads"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 {{- end }}
-{{- if .Values.workloads.kaiScheduler.enabled }}
-  - apiGroups: ["scheduling.run.ai"]
-    resources: ["podgroups"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-  - apiGroups: ["kai.scheduler"]
-    resources: ["topologies"]
-    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-{{- end }}
 {{- end }}

--- a/charts/anyscale-operator/templates/_rbac_rules.tpl
+++ b/charts/anyscale-operator/templates/_rbac_rules.tpl
@@ -34,4 +34,12 @@ The conditional logic for enableCrossNamespaceResourceManagement is handled in t
     resources: ["workloads"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
 {{- end }}
+{{- if .Values.workloads.kaiScheduler.enabled }}
+  - apiGroups: ["scheduling.run.ai"]
+    resources: ["podgroups"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["kai.scheduler"]
+    resources: ["topologies"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+{{- end }}
 {{- end }}

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -264,6 +264,14 @@ data:
           value: {{ $ingressClassName }}
     {{- end }}
 
+    {{- /* AWS-Specific Patches */ -}}
+    {{- if eq .Values.global.cloudProvider "aws" }}
+    ########################################
+    # AWS-Specific Patches
+    ########################################
+    {{- include "anyscale-operator.aws_specific_patches" . | nindent 4 }}
+    {{- end }}
+
     {{- /* AWS Credential Secret */ -}}
     {{- if .Values.credentialMount.aws.enabled }}
     ########################################

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -137,17 +137,6 @@ spec:
         {{- if .Values.workloads.enableCrossNamespaceResourceManagement }}
         - --enable-cross-namespace-resource-management=true
         {{- end }}
-        {{- if .Values.workloads.kaiScheduler.enabled }}
-        - --enable-stale-podgroup-reaper=true
-        {{- if .Values.workloads.kaiScheduler.stalePodGroupReaper }}
-        {{- if .Values.workloads.kaiScheduler.stalePodGroupReaper.reconcileInterval }}
-        - --stale-podgroup-reaper-reconcile-interval={{ .Values.workloads.kaiScheduler.stalePodGroupReaper.reconcileInterval }}
-        {{- end }}
-        {{- if .Values.workloads.kaiScheduler.stalePodGroupReaper.staleThreshold }}
-        - --stale-podgroup-reaper-stale-threshold={{ .Values.workloads.kaiScheduler.stalePodGroupReaper.staleThreshold }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
         resources:
 {{ toYaml .Values.operator.container.resources | indent 10 }}
         env:

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -137,10 +137,21 @@ spec:
         {{- if .Values.workloads.enableCrossNamespaceResourceManagement }}
         - --enable-cross-namespace-resource-management=true
         {{- end }}
+        {{- if .Values.workloads.kaiScheduler.enabled }}
+        - --enable-stale-podgroup-reaper=true
+        {{- if .Values.workloads.kaiScheduler.stalePodGroupReaper }}
+        {{- if .Values.workloads.kaiScheduler.stalePodGroupReaper.reconcileInterval }}
+        - --stale-podgroup-reaper-reconcile-interval={{ .Values.workloads.kaiScheduler.stalePodGroupReaper.reconcileInterval }}
+        {{- end }}
+        {{- if .Values.workloads.kaiScheduler.stalePodGroupReaper.staleThreshold }}
+        - --stale-podgroup-reaper-stale-threshold={{ .Values.workloads.kaiScheduler.stalePodGroupReaper.staleThreshold }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.operator.container.resources | indent 10 }}
         env:
-        {{- if .Values.global.aws.s3.usePathStyle }}
+        {{- if include "anyscale-operator.usePathStyle" . }}
         - name: ANYSCALE_S3_USE_PATH_STYLE
           value: "true"
         {{- end }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,7 +56,7 @@ global:
       operator:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: kubernetes_manager
-          tag: ci-1c50ff468e55cdf634c7153455d6c0f02550c952
+          tag: ci-268c63e5e7283355876c20a6a4bfad93fa4e736a
       vector:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: vector
@@ -480,6 +480,25 @@ workloads:
       #   H100: "NVIDIA-H100"
       #   H200: "nvidia-h200-80gb"
 
+  # NVIDIA KAI Scheduler configuration
+  # KAI is an open-source K8s-native GPU scheduler that supports topology-aware
+  # gang scheduling. When enabled, the Anyscale Operator will create PodGroup CRs
+  # for gang-scheduled workloads and apply KAI-specific annotations.
+  kaiScheduler:
+    # bool, enabled, default: false
+    # Whether to enable NVIDIA KAI Scheduler integration.
+    enabled: false
+    # Stale PodGroup reaper configuration.
+    # When KAI is enabled, the operator runs a reaper that garbage-collects
+    # orphaned KAI PodGroup CRs (no pending/running pods, no allocated resources).
+    stalePodGroupReaper:
+      # duration, reconcileInterval, default: 10m
+      # How often to check for stale PodGroups.
+      reconcileInterval: ""
+      # duration, staleThreshold, default: 25h
+      # How long a PodGroup must be orphaned before deletion.
+      staleThreshold: ""
+
 ################################################################
 # Additional patches
 ################################################################
@@ -543,7 +562,7 @@ operator:
     image:
       registry: us-docker.pkg.dev
       image: anyscale-artifacts/public/kubernetes_manager
-      tag: "ci-1c50ff468e55cdf634c7153455d6c0f02550c952"
+      tag: "ci-268c63e5e7283355876c20a6a4bfad93fa4e736a"
 
     resources:
       requests:

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -454,7 +454,7 @@ workloads:
         L40S: "NVIDIA-L40S"
         A100-40G: "NVIDIA-A100-SXM4-40GB"
         A100-80G: "NVIDIA-A100-SXM4-80GB"
-        H100: "NVIDIA-H100-PCIe-80GB"
+        H100: "NVIDIA-H100-80GB-HBM3"
 
       gcp:
         T4: "nvidia-tesla-t4"
@@ -479,25 +479,6 @@ workloads:
       # additional:
       #   H100: "NVIDIA-H100"
       #   H200: "nvidia-h200-80gb"
-
-  # NVIDIA KAI Scheduler configuration
-  # KAI is an open-source K8s-native GPU scheduler that supports topology-aware
-  # gang scheduling. When enabled, the Anyscale Operator will create PodGroup CRs
-  # for gang-scheduled workloads and apply KAI-specific annotations.
-  kaiScheduler:
-    # bool, enabled, default: false
-    # Whether to enable NVIDIA KAI Scheduler integration.
-    enabled: false
-    # Stale PodGroup reaper configuration.
-    # When KAI is enabled, the operator runs a reaper that garbage-collects
-    # orphaned KAI PodGroup CRs (no pending/running pods, no allocated resources).
-    stalePodGroupReaper:
-      # duration, reconcileInterval, default: 10m
-      # How often to check for stale PodGroups.
-      reconcileInterval: ""
-      # duration, staleThreshold, default: 25h
-      # How long a PodGroup must be orphaned before deletion.
-      staleThreshold: ""
 
 ################################################################
 # Additional patches


### PR DESCRIPTION
# Release `1.5.1`
## Bugfixes
- Fixes a bug where `.Values.global.aws.s3.usePathStyle` would make the
operator use path addressing style but the workloads it manages would
not. Now the operator and all workloads will now correctly use S3 path
addressing style when either `.Values.global.aws.s3.usePathStyle` or
`.Values.credentialMount.aws.createSecret.addressingStyle: path` are
set.
- Fixes a bug where operator would ignore values set by `HTTPS_PROXY`,
`HTTP_PROXY` and `NO_PROXY`.
- Fixes a bug where the operator would fail to build images on Azure due
to permissions errors.
- Updates default label selector value for H100 on AWS to be `"NVIDIA-H100-80GB-HBM3"`

**Full Changelog**:
https://github.com/anyscale/helm-charts/compare/anyscale-operator-1.5.0...anyscale-operator-1.5.1