### PR TITLE
Anyscale Operator 1.6.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 1.5.1
+version: 1.6.0
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -134,7 +134,7 @@ For advanced usage consult with Anyscale support.
 |-----------|------|---------|-------------|
 | `operator.container.image.registry` | string | `"us-docker.pkg.dev"` | Operator container image registry |
 | `operator.container.image.image` | string | `"anyscale-artifacts/public/kubernetes_manager"` | Operator container image name |
-| `operator.container.image.tag` | string | `ci-268c63e5e7283355876c20a6a4bfad93fa4e736a` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
+| `operator.container.image.tag` | string | `ci-5359115947981c7c16f18823af86ba6ec6e2e580` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
 | `operator.container.resources.requests.memory` | string | `"512Mi"` | Operator container memory request |
 | `operator.container.resources.requests.cpu` | int | `1` | Operator container CPU request |
 | `operator.container.resources.limits.memory` | string | `"2Gi"` | Operator container memory limit |

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
       tolerations:
 {{ toYaml .Values.operator.tolerations | indent 8 }}
       {{- end }}
+      {{- with .Values.operator.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- if .Values.operator.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.operator.imagePullSecrets | indent 8 }}
@@ -164,6 +168,10 @@ spec:
         volumeMounts:
           - name: logs
             mountPath: /tmp/anyscale/logs/
+          {{- with .Values.operator.securityContext }}
+          - name: anyscale-sockets
+            mountPath: /tmp/anyscale/sockets/
+          {{- end }}
           - name: patches
             mountPath: /tmp/config
           - name: vector-config
@@ -220,6 +228,10 @@ spec:
       volumes:
         - name: logs
           emptyDir: {}
+        {{- with .Values.operator.securityContext }}
+        - name: anyscale-sockets
+          emptyDir: {}
+        {{- end }}
         - name: patches
           configMap:
             name: patches

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,7 +56,7 @@ global:
       operator:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: kubernetes_manager
-          tag: ci-268c63e5e7283355876c20a6a4bfad93fa4e736a
+          tag: ci-5359115947981c7c16f18823af86ba6ec6e2e580
       vector:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: vector
@@ -530,6 +530,12 @@ operator:
   # tolerations allow the operator pod to schedule on nodes with matching taints
   tolerations: []
 
+  # map, securityContext, default: {}
+  # Pod-level securityContext applied verbatim to the operator pod template.
+  # Set runAsNonRoot/runAsUser/runAsGroup/fsGroup/fsGroupChangePolicy here to
+  # run the operator pod as a non-root user. Leave empty for default (root).
+  securityContext: {}
+
   # map, labels, default: {}
   # The labels to use for the operator pods.
   labels: {}
@@ -543,7 +549,7 @@ operator:
     image:
       registry: us-docker.pkg.dev
       image: anyscale-artifacts/public/kubernetes_manager
-      tag: "ci-268c63e5e7283355876c20a6a4bfad93fa4e736a"
+      tag: "ci-5359115947981c7c16f18823af86ba6ec6e2e580"
 
     resources:
       requests:


### PR DESCRIPTION
# Release 1.6.0
## Anyscale Operator Security Context
This release adds a new `operator.securityContext` field. This field acts as a passthrough allowing you to set the PodSecurityContext for the operator. For more information about the valid values for this field see the official Kubernetes docs link [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)

Full Changelog: https://github.com/anyscale/helm-charts/compare/anyscale-operator-1.5.1...anyscale-operator-1.6.0