### PR TITLE
Anyscale Operator 1.7.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 1.6.0
+version: 1.7.0
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -73,6 +73,7 @@ For advanced usage consult with Anyscale support.
 | `workloads.instanceTypes.enableDefaults` | bool | `true` | Whether to enable default instance types provided by the chart |
 | `workloads.instanceTypes.defaults` | object | See values.yaml | Default instance types (2CPU-8GB, 4CPU-16GB, 8CPU-32GB, 8CPU-32GB-1xT4). These provide Pod shapes that can be used in Anyscale workloads. |
 | `workloads.instanceTypes.additional` | object | `{}` | Additional user-defined instance types. If `enableDefaults` is true, these merge with defaults. If false, these replace defaults. See values.yaml for schema and examples. |
+| `workloads.instanceTypes.validationHook.enabled` | bool | `true` | Run the pre-install/pre-upgrade Helm hook that validates the instance-types ConfigMap against the Anyscale Control Plane before the release is applied. Set to `false` to skip this pre-flight check (e.g. when the Control Plane is not reachable from the cluster at install time). Does not affect the runtime validating webhook, which still validates instance-types ConfigMap changes. |
 
 #### Workload Features
 
@@ -134,7 +135,7 @@ For advanced usage consult with Anyscale support.
 |-----------|------|---------|-------------|
 | `operator.container.image.registry` | string | `"us-docker.pkg.dev"` | Operator container image registry |
 | `operator.container.image.image` | string | `"anyscale-artifacts/public/kubernetes_manager"` | Operator container image name |
-| `operator.container.image.tag` | string | `ci-5359115947981c7c16f18823af86ba6ec6e2e580` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
+| `operator.container.image.tag` | string | `ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
 | `operator.container.resources.requests.memory` | string | `"512Mi"` | Operator container memory request |
 | `operator.container.resources.requests.cpu` | int | `1` | Operator container CPU request |
 | `operator.container.resources.limits.memory` | string | `"2Gi"` | Operator container memory limit |
@@ -155,7 +156,7 @@ For advanced usage consult with Anyscale support.
 | `operator.config.unscheduledPodReaper.reconcileInterval` | duration | `"1m"` | Interval at which the unscheduled pod reaper should reconcile |
 | `operator.config.unscheduledPodReaper.terminationThreshold` | duration | `"10m"` | Threshold after which an unscheduled Pod should be considered leaked and terminated |
 | `operator.config.status.reportingEnabled` | bool | `true` | Whether to enable status reporting to the Anyscale Control Plane |
-| `operator.config.status.excludeComponentVerification` | array | `[]` | Components to skip verification for during startup and status checks. Valid values: STORAGE_BUCKET, KUBERNETES_VERSION, GATEWAY_RESOURCES, CLOUD_RESOURCES, IAM_IDENTITY, KUBERNETES_PERMISSIONS |
+| `operator.config.status.excludeComponentVerification` | array | `[]` | Components to skip verification for during startup and status checks. Valid values: STORAGE_BUCKET, KUBERNETES_VERSION, GATEWAY_RESOURCES, CLOUD_RESOURCES, IAM_IDENTITY, KUBERNETES_PERMISSIONS, INSTANCE_TYPES. INSTANCE_TYPES is auto-appended by the chart when no instance types are defined. |
 | `operator.config.status.checkInterval` | duration | `"5m"` | Interval for status checks |
 | `operator.config.status.reportInterval` | duration | `"30s"` | Interval for status reporting |
 

--- a/charts/anyscale-operator/templates/_helpers.tpl
+++ b/charts/anyscale-operator/templates/_helpers.tpl
@@ -13,6 +13,34 @@ Validate controlPlaneURL to ensure it doesn't end with a trailing slash
 {{- if or .Values.global.aws.s3.usePathStyle (eq (.Values.credentialMount.aws.createSecret.addressingStyle | default "") "path") -}}true{{- end -}}
 {{- end -}}
 
+{{/*
+Returns the merged workload instance types (defaults + additional) as YAML.
+This is the single source of truth for what lands in the instance-types
+ConfigMap; the ConfigMap template, the pre-install validation hook, and the
+hasInstanceTypes gate all MUST consume this helper so they never disagree
+about what is being deployed.
+*/}}
+{{- define "anyscale-operator.mergedInstanceTypes" -}}
+{{- $allInstanceTypes := dict -}}
+{{- if .Values.workloads.instanceTypes.enableDefaults -}}
+  {{- $allInstanceTypes = merge $allInstanceTypes (default dict .Values.workloads.instanceTypes.defaults) -}}
+{{- end -}}
+{{- $allInstanceTypes = merge $allInstanceTypes (default dict .Values.workloads.instanceTypes.additional) -}}
+{{- $allInstanceTypes | toYaml -}}
+{{- end -}}
+
+{{/*
+Returns the truthy string "true" when at least one workload instance type
+will be rendered into the instance-types ConfigMap, otherwise empty. The
+ConfigMap (configmap_instance_types.yaml) and the operator's instance-types
+validator (deployment.yaml --exclude-component-verification) MUST agree, so
+both consume this helper.
+*/}}
+{{- define "anyscale-operator.hasInstanceTypes" -}}
+{{- $merged := fromYaml (include "anyscale-operator.mergedInstanceTypes" .) -}}
+{{- if $merged -}}true{{- end -}}
+{{- end -}}
+
 {{- define "anyscale-operator.aws_specific_patches" -}}
 {{- $headContainerIndices := list 0 1 2 5 -}}{{/* ray, vector, anyscaled, activity-probe */}}
 {{- $workerContainerIndices := list 0 1 2 3 -}}{{/* ray, vector, anyscaled, activity-probe */}}

--- a/charts/anyscale-operator/templates/configmap_instance_types.yaml
+++ b/charts/anyscale-operator/templates/configmap_instance_types.yaml
@@ -1,11 +1,5 @@
-{{- $allInstanceTypes := dict }}
-{{- if .Values.workloads.instanceTypes.enableDefaults }}
-  {{- $allInstanceTypes = merge $allInstanceTypes (default dict .Values.workloads.instanceTypes.defaults) }}
-{{- end }}
-{{- $allInstanceTypes = merge $allInstanceTypes (default dict .Values.workloads.instanceTypes.additional) }}
-
-{{- /* Only render the ConfigMap if there are instance types defined. This allows users to disable default instance types without additional configuration. */ -}}
-{{- if $allInstanceTypes }}
+{{- /* Only render the ConfigMap if there are instance types defined. This allows users to disable default instance types without additional configuration. The deployment template uses the same helper to decide whether to skip the instance-types validator check. */ -}}
+{{- if include "anyscale-operator.hasInstanceTypes" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,5 +14,5 @@ metadata:
 data:
   version: v1
   instance_types.yaml: |-
-{{ toYaml $allInstanceTypes | indent 4 }}
+{{ include "anyscale-operator.mergedInstanceTypes" . | indent 4 }}
 {{- end }}

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -125,10 +125,12 @@ spec:
         - --leader-election-lease-namespace={{ .Release.Namespace }}
         - --leader-election-lease-name=anyscale-operator-lease
         {{- end }}
-        {{- if .Values.operator.config.status.excludeComponentVerification }}
-        {{- range .Values.operator.config.status.excludeComponentVerification }}
-        - --exclude-component-verification={{ . }}
+        {{- $excludes := .Values.operator.config.status.excludeComponentVerification | default (list) -}}
+        {{- if and (not (include "anyscale-operator.hasInstanceTypes" .)) (not (has "INSTANCE_TYPES" $excludes)) -}}
+        {{- $excludes = append $excludes "INSTANCE_TYPES" -}}
         {{- end }}
+        {{- range $excludes }}
+        - --exclude-component-verification={{ . }}
         {{- end }}
         {{- if .Values.operator.config.status.reportingEnabled }}
         - --enable-status-reporting=true
@@ -141,6 +143,13 @@ spec:
         {{- if .Values.workloads.enableCrossNamespaceResourceManagement }}
         - --enable-cross-namespace-resource-management=true
         {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          periodSeconds: 3
+          timeoutSeconds: 3
+          failureThreshold: 3
         resources:
 {{ toYaml .Values.operator.container.resources | indent 10 }}
         env:

--- a/charts/anyscale-operator/templates/instance_types_validation_hook.yaml
+++ b/charts/anyscale-operator/templates/instance_types_validation_hook.yaml
@@ -1,0 +1,127 @@
+{{- /*
+On a clean install, Helm's resource-kind ordering applies the instance-types
+ConfigMap before the ValidatingWebhookConfiguration, so the first ConfigMap
+slips past validation. This pre-install/pre-upgrade hook POSTs the planned
+ConfigMap to the same admission endpoint the webhook would call, so a bad
+configuration fails the release up front instead of being caught later by the
+webhook on the next reconfigure.
+*/ -}}
+{{- if and .Values.workloads.instanceTypes.validationHook.enabled (include "anyscale-operator.hasInstanceTypes" .) }}
+{{- $cmName := .Values.workloads.instanceTypes.configMap.name | default "instance-types" }}
+{{- $instanceTypesYaml := include "anyscale-operator.mergedInstanceTypes" . }}
+{{- $hookName := printf "%s-instance-types-validation" .Values.operator.name }}
+{{- $admissionReview := dict
+  "apiVersion" "admission.k8s.io/v1"
+  "kind" "AdmissionReview"
+  "request" (dict
+    "uid" (printf "%s-helm-pre-install" .Release.Name)
+    "kind" (dict "group" "" "version" "v1" "kind" "ConfigMap")
+    "resource" (dict "group" "" "version" "v1" "resource" "configmaps")
+    "name" $cmName
+    "namespace" .Release.Namespace
+    "operation" "CREATE"
+    "object" (dict
+      "apiVersion" "v1"
+      "kind" "ConfigMap"
+      "metadata" (dict
+        "name" $cmName
+        "namespace" .Release.Namespace
+        "labels" (dict "anyscale.com/name" "instance-types")
+      )
+      "data" (dict
+        "version" "v1"
+        "instance_types.yaml" $instanceTypesYaml
+      )
+    )
+  )
+}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  admission-review.json: |-
+{{ toJson $admissionReview | indent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $hookName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: instance-types-validation
+    spec:
+      restartPolicy: Never
+      {{- if .Values.operator.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.operator.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.operator.affinity }}
+      affinity:
+{{ toYaml .Values.operator.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.operator.tolerations }}
+      tolerations:
+{{ toYaml .Values.operator.tolerations | indent 8 }}
+      {{- end }}
+      {{- with .Values.operator.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.operator.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.operator.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+      - name: validate
+        {{- $operatorImage := "" -}}
+        {{- if .Values.global.azure.extension.enabled -}}
+        {{- $operatorImage = .Values.global.azure.images.operator -}}
+        {{- else -}}
+        {{- $operatorImage = .Values.operator.container.image -}}
+        {{- end -}}
+        {{- with $operatorImage }}
+        image: '{{ if .registry }}{{ .registry }}/{{ end }}{{ .image }}:{{ .tag }}'
+        {{- end }}
+        imagePullPolicy: {{ .Values.operator.container.imagePullPolicy | default "IfNotPresent" }}
+        command: ["/app/go/infra/kubernetes_manager/kubernetes_manager"]
+        args:
+        - --log-level=info
+        - validate-instance-types
+        - --control-plane-url={{ include "anyscale-operator.validateControlPlaneURL" . }}
+        - --cloud-deployment-id={{ required "global.cloudDeploymentId is required" .Values.global.cloudDeploymentId }}
+        - --admission-review-file=/admission/admission-review.json
+        volumeMounts:
+        - name: admission-review
+          mountPath: /admission
+          readOnly: true
+      volumes:
+      - name: admission-review
+        configMap:
+          name: {{ $hookName }}
+{{- end }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,7 +56,7 @@ global:
       operator:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: kubernetes_manager
-          tag: ci-5359115947981c7c16f18823af86ba6ec6e2e580
+          tag: ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17
       vector:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: vector
@@ -142,6 +142,17 @@ workloads:
     # The name of the ConfigMap to store the instance types.
     configMap:
       name: "instance-types"
+
+    # Instance-type validation hook
+    validationHook:
+      # bool, enabled, default: true
+      # Whether to run the pre-install/pre-upgrade Helm hook that validates the
+      # instance-types ConfigMap against the Anyscale Control Plane before the
+      # release is applied. The hook POSTs the planned ConfigMap to the same
+      # admission endpoint as the runtime ValidatingWebhookConfiguration, so an
+      # invalid configuration fails `helm install`/`helm upgrade` up front
+      # instead of being caught later on the next reconfigure.
+      enabled: true
 
     # bool, enableDefaults, default: true
     # Whether to enable default instance types.
@@ -549,7 +560,7 @@ operator:
     image:
       registry: us-docker.pkg.dev
       image: anyscale-artifacts/public/kubernetes_manager
-      tag: "ci-5359115947981c7c16f18823af86ba6ec6e2e580"
+      tag: "ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17"
 
     resources:
       requests:
@@ -614,8 +625,12 @@ operator:
       #  - CLOUD_RESOURCES
       #  - IAM_IDENTITY
       #  - KUBERNETES_PERMISSIONS
+      #  - INSTANCE_TYPES
       #
       # By default, all components will be verified during the operator startup sequence.
+      # Note: INSTANCE_TYPES is automatically appended by the chart when no instance
+      # types are defined (workloads.instanceTypes.enableDefaults=false with no additional
+      # entries), since the instance-types ConfigMap is also skipped in that case.
       excludeComponentVerification: []
       checkInterval: "5m"
       reportInterval: "30s"


### PR DESCRIPTION
# Release 1.7.0
This release adds additional validations to ensure that errors in operator installation or upgrade are caught early and made visible.

## Anyscale Operator Readiness Probe

The operator now exposes /readyz on port 8081 and the Helm Deployment configures a matching readinessProbe. `helm install --wait and helm upgrade --wait` will no longer return success while the operator is still starting up or crash-looping.

## New fields
1. workloads.instanceTypes.validationHook.enabled: a pre-install/pre-upgrade Helm hook validates the planned instance-types ConfigMap against the control plane and fails the release on invalid types. Set to false when the control plane is not reachable at install time.

## Bugfixes
1. Declarative-only operator setups (no instance-types) no longer fail operator startup.

Full Changelog: https://github.com/anyscale/helm-charts/compare/anyscale-operator-1.6.0...anyscale-operator-1.7.0
This release is backward-compatible and recommended for all users.