### PR TITLE
Anyscale Operator 1.7.1

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 1.7.0
+version: 1.7.1
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -135,7 +135,7 @@ For advanced usage consult with Anyscale support.
 |-----------|------|---------|-------------|
 | `operator.container.image.registry` | string | `"us-docker.pkg.dev"` | Operator container image registry |
 | `operator.container.image.image` | string | `"anyscale-artifacts/public/kubernetes_manager"` | Operator container image name |
-| `operator.container.image.tag` | string | `ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
+| `operator.container.image.tag` | string | `ci-a079880ab66977d1b954cad5cd8ecadf4bba4ea8` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
 | `operator.container.resources.requests.memory` | string | `"512Mi"` | Operator container memory request |
 | `operator.container.resources.requests.cpu` | int | `1` | Operator container CPU request |
 | `operator.container.resources.limits.memory` | string | `"2Gi"` | Operator container memory limit |

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,7 +56,7 @@ global:
       operator:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: kubernetes_manager
-          tag: ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17
+          tag: ci-a079880ab66977d1b954cad5cd8ecadf4bba4ea8
       vector:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: vector
@@ -560,7 +560,7 @@ operator:
     image:
       registry: us-docker.pkg.dev
       image: anyscale-artifacts/public/kubernetes_manager
-      tag: "ci-2c43cde542a2c6e856c6e49bc99812d7d2f78e17"
+      tag: "ci-a079880ab66977d1b954cad5cd8ecadf4bba4ea8"
 
     resources:
       requests:


### PR DESCRIPTION
# Release `1.7.1`

## Bugfixes
- fix issue in Azure Marketplace Offer where an incorrect role name was
being rendered
- bump operator Amazon Linux 2023 base image to `2023.11.20260526.0`

This release is backwards compatible and is recommended for all users.
**Full Changelog**:

https://github.com/anyscale/helm-charts/compare/anyscale-operator-1.7.0...anyscale-operator-1.7.1