### PR TITLE
Add best-effort workflow to notify Anyscale docs of operator releases

### DIFF
--- a/.github/workflows/notify-docs-operator-release.yml
+++ b/.github/workflows/notify-docs-operator-release.yml
@@ -1,0 +1,65 @@
+name: Notify docs of operator release
+
+# Best-effort, non-blocking notification. When a new anyscale-operator chart
+# version lands on master (the same push that triggers the chart-releaser
+# workflow), tell the Anyscale documentation repo so it can draft the release
+# notes. This runs as a separate workflow and is allowed to fail, so it can
+# never block or affect the chart release.
+#
+# Why this trigger and not `release: published`: the chart-releaser workflow
+# creates releases with the default GITHUB_TOKEN, and releases created that way
+# do not trigger other workflows (GitHub's recursion guard). The version-bump
+# push to master is a real user event, so it fires reliably.
+#
+# Requires a repository secret DOCS_DISPATCH_GH_TOKEN: a token that can create a
+# repository_dispatch on anyscale/docs (Contents: write on that repo). Until the
+# secret is set, this workflow no-ops gracefully.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'charts/anyscale-operator/Chart.yaml'
+
+jobs:
+  notify-docs:
+    runs-on: ubuntu-latest
+    # Best-effort: a docs-side failure must not turn the release red.
+    continue-on-error: true
+    steps:
+      - name: Check out the chart
+        uses: actions/checkout@v4
+
+      - name: Notify anyscale/docs of the operator release
+        env:
+          DOCS_DISPATCH_GH_TOKEN: ${{ secrets.DOCS_DISPATCH_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          CHART=charts/anyscale-operator/Chart.yaml
+          VERSION=$(grep -E '^version:' "$CHART" | head -1 | awk '{print $2}' | tr -d '"')
+          if [ -z "${VERSION:-}" ]; then
+            echo "Could not read the chart version from ${CHART}; skipping."
+            exit 0
+          fi
+
+          if [ -z "${DOCS_DISPATCH_GH_TOKEN:-}" ]; then
+            echo "DOCS_DISPATCH_GH_TOKEN is not configured; skipping notification (best-effort)."
+            exit 0
+          fi
+
+          TAG="anyscale-operator-${VERSION}"
+          RELEASE_URL="https://github.com/anyscale/helm-charts/releases/tag/${TAG}"
+          PAYLOAD=$(jq -n \
+            --arg version "$VERSION" --arg tag "$TAG" --arg url "$RELEASE_URL" \
+            '{"event_type": "operator-release", "client_payload": {"version": $version, "tag": $tag, "release_url": $url}}')
+
+          # A duplicate notification is harmless: the docs receiver is idempotent
+          # on the version, so it won't create a second ticket.
+          curl -f -S -X POST \
+            -H "Authorization: token ${DOCS_DISPATCH_GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/anyscale/docs/dispatches \
+            -d "${PAYLOAD}"
+          echo "Notified anyscale/docs of operator ${VERSION}."

--- a/.github/workflows/notify-docs-operator-release.yml
+++ b/.github/workflows/notify-docs-operator-release.yml
@@ -20,6 +20,14 @@ on:
     branches: [master]
     paths:
       - 'charts/anyscale-operator/Chart.yaml'
+  # Manual trigger for testing the round-trip without a real release. Provide a
+  # throwaway version like 0.0.0-test; the docs receiver dedupes on the version.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Operator version to notify docs about (defaults to the current Chart.yaml version)."
+        required: false
+        type: string
 
 jobs:
   notify-docs:
@@ -33,13 +41,18 @@ jobs:
       - name: Notify anyscale/docs of the operator release
         env:
           DOCS_DISPATCH_GH_TOKEN: ${{ secrets.DOCS_DISPATCH_GH_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
           CHART=charts/anyscale-operator/Chart.yaml
-          VERSION=$(grep -E '^version:' "$CHART" | head -1 | awk '{print $2}' | tr -d '"')
+          # Use the manually supplied version if present, else read the chart.
+          VERSION="${INPUT_VERSION:-}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(grep -E '^version:' "$CHART" | head -1 | awk '{print $2}' | tr -d '"')
+          fi
           if [ -z "${VERSION:-}" ]; then
-            echo "Could not read the chart version from ${CHART}; skipping."
+            echo "Could not determine the chart version; skipping."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Adds a best-effort, non-blocking workflow that notifies the Anyscale documentation repo when a new `anyscale-operator` chart version is published, so the docs team can bring the operator release notes into the docs site. Proposed by the Anyscale docs team.

## What it does

`.github/workflows/notify-docs-operator-release.yml` — on a push to `master` that changes `charts/anyscale-operator/Chart.yaml`, it reads the new chart version and POSTs a `repository_dispatch` to `anyscale/docs` carrying the version, tag, and release URL. The docs repo files a tracking ticket and drafts the release notes from it.

## Why this trigger, not `release: published`

The chart-releaser workflow creates releases with the default `GITHUB_TOKEN`, and releases created that way don't trigger other workflows (GitHub's recursion guard), so a `release`-event hook would never fire. The version-bump push to `master` is the same event that already triggers chart-releaser and is a real user event, so it fires reliably.

## Safety and blast radius

- Runs as a **separate** workflow from the release, so it can never block or affect the chart release.
- `continue-on-error: true`, and it no-ops gracefully if the version can't be read.
- Sends only the version, tag, and release URL. No secrets or sensitive content leave the repo.

## One secret to configure (maintainers)

Set a repository secret **`DOCS_DISPATCH_GH_TOKEN`** to a token that can create a `repository_dispatch` on `anyscale/docs`: a fine-grained PAT or GitHub App with **Contents: write** on `anyscale/docs`, or a classic PAT with the `repo` scope. Until the secret exists, the workflow no-ops gracefully with no failures.

## Testing

After the secret is set, merging the next operator release (or any `Chart.yaml` version bump) should show this workflow POST the dispatch, and a tracking ticket appears on the docs side. A duplicate notification is harmless: the docs receiver is idempotent on the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
