### PR TITLE
Anyscale Operator 1.7.2

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 1.7.1
+version: 1.7.2
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -135,16 +135,18 @@ For advanced usage consult with Anyscale support.
 |-----------|------|---------|-------------|
 | `operator.container.image.registry` | string | `"us-docker.pkg.dev"` | Operator container image registry |
 | `operator.container.image.image` | string | `"anyscale-artifacts/public/kubernetes_manager"` | Operator container image name |
-| `operator.container.image.tag` | string | `ci-a079880ab66977d1b954cad5cd8ecadf4bba4ea8` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
+| `operator.container.image.tag` | string | `ci-00e6d0075d63c550082ad6856abddf8adb96e7bd` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
 | `operator.container.resources.requests.memory` | string | `"512Mi"` | Operator container memory request |
 | `operator.container.resources.requests.cpu` | int | `1` | Operator container CPU request |
 | `operator.container.resources.limits.memory` | string | `"2Gi"` | Operator container memory limit |
+| `operator.container.additionalEnv` | array | `[]` | Extra env vars appended to the operator container (standard k8s `env` schema: name/value or name/valueFrom), after the built-in env vars, so a colliding name overrides the built-in. Also applied to the pre-install/pre-upgrade instance-types validation hook, which runs the operator image and calls the control plane, so proxy settings take effect during `helm install`/`upgrade` too. For pod-wide env such as an HTTP proxy (HTTP_PROXY/HTTPS_PROXY/NO_PROXY), also set `operator.vector.additionalEnv`. |
 | `operator.vector.image.registry` | string | `""` | Vector sidecar image registry (empty string uses default docker.io) |
 | `operator.vector.image.image` | string | `"timberio/vector"` | Vector sidecar image name |
 | `operator.vector.image.tag` | string | `"0.40.0-debian"` | Vector sidecar image tag |
 | `operator.vector.resources.requests.cpu` | string | `"100m"` | Vector sidecar CPU request |
 | `operator.vector.resources.requests.memory` | string | `"512Mi"` | Vector sidecar memory request |
 | `operator.vector.resources.limits.memory` | string | `"512Mi"` | Vector sidecar memory limit |
+| `operator.vector.additionalEnv` | array | `[]` | Extra env vars appended to the vector sidecar (same schema as `operator.container.additionalEnv`). Set both for env every container in the pod must share. |
 
 #### Operator Configuration
 

--- a/charts/anyscale-operator/templates/deployment.yaml
+++ b/charts/anyscale-operator/templates/deployment.yaml
@@ -174,6 +174,9 @@ spec:
         - name: GCLOUD_PROJECT
           value: {{ required "global.gcp.projectId is required for GCP credential mount" .Values.global.gcp.projectId }}
         {{- end }}
+        {{- with .Values.operator.container.additionalEnv }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
         volumeMounts:
           - name: logs
             mountPath: /tmp/anyscale/logs/
@@ -222,6 +225,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        {{- with .Values.operator.vector.additionalEnv }}
+{{ toYaml . | indent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.operator.vector.resources | indent 10 }}
         volumeMounts:

--- a/charts/anyscale-operator/templates/instance_types_validation_hook.yaml
+++ b/charts/anyscale-operator/templates/instance_types_validation_hook.yaml
@@ -116,6 +116,10 @@ spec:
         - --control-plane-url={{ include "anyscale-operator.validateControlPlaneURL" . }}
         - --cloud-deployment-id={{ required "global.cloudDeploymentId is required" .Values.global.cloudDeploymentId }}
         - --admission-review-file=/admission/admission-review.json
+        {{- with .Values.operator.container.additionalEnv }}
+        env:
+{{ toYaml . | indent 8 }}
+        {{- end }}
         volumeMounts:
         - name: admission-review
           mountPath: /admission

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,7 +56,7 @@ global:
       operator:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: kubernetes_manager
-          tag: ci-a079880ab66977d1b954cad5cd8ecadf4bba4ea8
+          tag: ci-00e6d0075d63c550082ad6856abddf8adb96e7bd
       vector:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: vector
@@ -560,7 +560,7 @@ operator:
     image:
       registry: us-docker.pkg.dev
       image: anyscale-artifacts/public/kubernetes_manager
-      tag: "ci-a079880ab66977d1b954cad5cd8ecadf4bba4ea8"
+      tag: "ci-00e6d0075d63c550082ad6856abddf8adb96e7bd"
 
     resources:
       requests:
@@ -568,6 +568,17 @@ operator:
         cpu: 1
       limits:
         memory: 2Gi
+
+    # array, additionalEnv, default: []
+    # Extra environment variables to add to the operator container, using the
+    # standard Kubernetes env schema (name/value or name/valueFrom). Added after
+    # the built-in env vars. To apply env to the whole pod (e.g. an HTTP proxy),
+    # also set operator.vector.additionalEnv.
+    # Example:
+    # additionalEnv:
+    #   - name: HTTPS_PROXY
+    #     value: "http://proxy.internal:3128"
+    additionalEnv: []
 
   serviceAccount:
     name: anyscale-operator
@@ -585,6 +596,12 @@ operator:
         memory: 512Mi
       limits:
         memory: 512Mi
+
+    # array, additionalEnv, default: []
+    # Extra environment variables to add to the vector sidecar (same schema as
+    # operator.container.additionalEnv). Set both to apply env to every container
+    # in the pod.
+    additionalEnv: []
 
   # Deployment configuration.
   # NOTE: To configure the operator deployment's pod template, use the fields above


### PR DESCRIPTION
# Release `1.7.2`

## Additional AWS Region Support
Operator cloud setup now works in 12 more commercial AWS regions.Newly
supported:
- Jakarta (`ap-southeast-3`)
- Melbourne (`ap-southeast-4`)
- Kuala Lumpur (`ap-southeast-5`)
- Bangkok (`ap-southeast-7`)
- Hyderabad (`ap-south-2`)
- Taipei (`ap-east-2`)
- Calgary (`ca-west-1`)
- Zurich (`eu-central-2`)
- Spain (`eu-south-2`)
- Tel Aviv (`il-central-1`)
- UAE (`me-central-1`)
- Querétaro (`mx-central-1`)

## Custom Environment Variables
Two new fields append environment variables to the operator pod.

New fields:
1. `operator.container.additionalEnv`: env vars for the operator
container. These also reach the pre-install/upgrade instance-types
validation hook.
2. `operator.vector.additionalEnv`: env vars for the vector logging
sidecar.

Both default to empty, so existing installs are unaffected. This is
useful for when additional variables need to be present in the operator,
such as HTTP Proxy configurations.

## Distroless Operator Image
This release moves the operator image from Amazon Linux 2023 to a
distroless base, reducing its size and vulnerability surface.

This release is backwards compatible and is recommended for all users.

**Full Changelog**:
anyscale/helm-charts@anyscale-operator-1.7.1...anyscale-operator-1.7.2