### PR TITLE
Anyscale Operator 1.8.0

### DIFF
--- a/charts/anyscale-operator/Chart.yaml
+++ b/charts/anyscale-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Anyscale Operator
 name: anyscale-operator
-version: 1.7.2
+version: 1.8.0
 dependencies:
 - name: ingress-nginx
   version: "4.13.2"

--- a/charts/anyscale-operator/README.md
+++ b/charts/anyscale-operator/README.md
@@ -66,6 +66,14 @@ For advanced usage consult with Anyscale support.
 | `workloads.serviceAccount.name` | string | `""` | Service account name for Anyscale workload pods. If not set, uses the default service account. |
 | `workloads.serviceAccount.iamMappingAnnotation` | string | `"anyscale.com/iam-mapping"` | Annotation key used to identify pods that use IAM mapping. If present, the operator will skip applying `workloads.serviceAccount.name` to the pod. |
 
+#### Image Pull Secrets
+
+Use these to pull workload container images from a private registry (e.g. a self-hosted registry in your own cloud project).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `workloads.imagePullSecrets` | array | `[]` | Secrets added to every Anyscale workload pod's `spec.imagePullSecrets`. Each entry's `name` is injected into the pod. Multiple entries are supported. By default the referenced secret must already exist in the pod's namespace. Set `create: true` on an entry to have the chart also create the secret in the operator namespace and sync it into every managed namespace (via the `anyscale.com/sync-to-managed-namespaces: "true"` label); the entry's `data` (rendered as-is under the Secret's `data`) and optional `type` (default `kubernetes.io/dockerconfigjson`) are used to build it. See values.yaml for an example. |
+
 #### Instance Types
 
 | Parameter | Type | Default | Description |
@@ -135,7 +143,7 @@ For advanced usage consult with Anyscale support.
 |-----------|------|---------|-------------|
 | `operator.container.image.registry` | string | `"us-docker.pkg.dev"` | Operator container image registry |
 | `operator.container.image.image` | string | `"anyscale-artifacts/public/kubernetes_manager"` | Operator container image name |
-| `operator.container.image.tag` | string | `ci-00e6d0075d63c550082ad6856abddf8adb96e7bd` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
+| `operator.container.image.tag` | string | `ci-52a05abd5073d2f973e41f23cf5a4076ea033579` | Operator container image tag. Updated with helm releases. Anyscale support may provide preview versions. |
 | `operator.container.resources.requests.memory` | string | `"512Mi"` | Operator container memory request |
 | `operator.container.resources.requests.cpu` | int | `1` | Operator container CPU request |
 | `operator.container.resources.limits.memory` | string | `"2Gi"` | Operator container memory limit |

--- a/charts/anyscale-operator/templates/configmap_patches.yaml
+++ b/charts/anyscale-operator/templates/configmap_patches.yaml
@@ -25,6 +25,25 @@ data:
           value: "{{ .Values.workloads.serviceAccount.name }}"
     {{- end }}
 
+    {{- /* Image Pull Secrets */ -}}
+    {{- if .Values.workloads.imagePullSecrets }}
+    ########################################
+    # Image Pull Secrets
+    ########################################
+    # Inject imagePullSecrets into every workload pod so images can be pulled
+    # from a private registry. Appending to /spec/imagePullSecrets/- is safe
+    # whether or not the pod already declares the array (the operator applies
+    # patches with EnsurePathExistsOnAdd).
+    - kind: Pod
+      patch:
+        {{- range .Values.workloads.imagePullSecrets }}
+        - op: add
+          path: /spec/imagePullSecrets/-
+          value:
+            name: {{ required "workloads.imagePullSecrets[].name is required" .name }}
+        {{- end }}
+    {{- end }}
+
     {{- /* Azure Workload Identity Support */ -}}
     {{- if eq .Values.global.cloudProvider "azure" }}
     - kind: Pod

--- a/charts/anyscale-operator/templates/credentials.yaml
+++ b/charts/anyscale-operator/templates/credentials.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    anyscale.com/sync-to-managed-namespaces: "true"
 data:
   credentials: {{ include "anyscale-operator.aws_credentials" . | b64enc | quote }}
   config: {{ include "anyscale-operator.aws_config" . | b64enc | quote }}
@@ -25,6 +26,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    anyscale.com/sync-to-managed-namespaces: "true"
 data:
   key.json: {{ required "credentialMount.gcp.createSecret.keyJsonB64 is required for GCP credential mount when credentialMount.gcp.createSecret.create is true" .Values.credentialMount.gcp.createSecret.keyJsonB64 | quote }}
 {{- end }}

--- a/charts/anyscale-operator/templates/registry_credentials.yaml
+++ b/charts/anyscale-operator/templates/registry_credentials.yaml
@@ -1,0 +1,19 @@
+{{- range $secret := .Values.workloads.imagePullSecrets }}
+{{- if $secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ required "workloads.imagePullSecrets[].name is required" $secret.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    anyscale.com/sync-to-managed-namespaces: "true"
+type: {{ $secret.type | default "kubernetes.io/dockerconfigjson" }}
+data:
+{{ required (printf "workloads.imagePullSecrets[].data is required to create secret %q" $secret.name) $secret.data | toYaml | indent 2 }}
+---
+{{- end }}
+{{- end }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -56,7 +56,7 @@ global:
       operator:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: kubernetes_manager
-          tag: ci-00e6d0075d63c550082ad6856abddf8adb96e7bd
+          tag: ci-52a05abd5073d2f973e41f23cf5a4076ea033579
       vector:
           registry: anyscaleoperator.azurecr.io/anyscale
           image: vector
@@ -135,6 +135,22 @@ workloads:
     # The annotation key used to identify pods that use IAM mapping.
     # If this annotation is present, the Anyscale Operator will skip applying `workload.serviceAccount.name` to the pod.
     iamMappingAnnotation: "anyscale.com/iam-mapping"
+
+  # array, imagePullSecrets, default: []
+  # Secret refs added to every workload pod's `spec.imagePullSecrets` (for pulling images from a private registry).
+  # Each entry's `name` is injected into the pod. By default the secret must already exist in the pod's namespace.
+  # Set `create: true` to have the chart also create the secret in the operator namespace and sync it (via the
+  # `anyscale.com/sync-to-managed-namespaces` label) into every managed namespace; `data` (rendered as-is under the
+  # Secret's `data`) and `type` are then used to build it.
+  # Example:
+  #   imagePullSecrets:
+  #     - name: existing-registry-creds          # reference-only: must already exist / be synced
+  #     - name: anyscale-ray-registry-credentials # chart-managed: created, synced, and injected
+  #       create: true
+  #       type: kubernetes.io/dockerconfigjson    # default: kubernetes.io/dockerconfigjson
+  #       data:
+  #         .dockerconfigjson: "<base64 of a .dockerconfigjson>"
+  imagePullSecrets: []
 
   # Instance types configuration
   instanceTypes:
@@ -560,7 +576,7 @@ operator:
     image:
       registry: us-docker.pkg.dev
       image: anyscale-artifacts/public/kubernetes_manager
-      tag: "ci-00e6d0075d63c550082ad6856abddf8adb96e7bd"
+      tag: "ci-52a05abd5073d2f973e41f23cf5a4076ea033579"
 
     resources:
       requests:


### PR DESCRIPTION
# Release 1.8.0

### Image Pull Secrets for Workload Pods

You can now manage image pull secrets via the chart. This will allow you to both create new secrets and automate mounting existing secrets into every workload pod created.

### Secret Syncing into Managed Namespaces

Any secret in the operator namespace labeled `anyscale.com/sync-to-managed-namespaces: "true"` is now copied into every managed namespace, so workload pods outside the operator namespace can mount it. The chart stamps that label on the AWS and GCP credentialMount secrets and on image pull secrets it creates.

Requires `workloads.enableCrossNamespaceResourceManagement: true` and a non-empty `workloads.managedNamespaces`. Both are off by default, so existing installs are unaffected.

### Azure Per-Cloud Control Plane Endpoint

controlPlaneUrl now defaults to empty and the Marketplace template derives a per-cloud endpoint from the cloud it creates. Set controlPlaneUrl explicitly to override.

## New fields:
`workloads.imagePullSecrets`: secret refs added to every workload pod's spec.imagePullSecrets. The secret must already exist in the pod's namespace, or set create: true to have the chart create it in the operator namespace from the data you supply.

A chart-created secret reaches workload namespaces only when secret syncing is enabled, below. Defaults to empty, so existing installs are unaffected.

## Misc
- significantly improved operator performance when launching large clusters (1000s of pods)

This release is backwards compatible and is recommended for all users.

Full Changelog:
https://github.com/anyscale/helm-charts/compare/anyscale-operator-1.7.2...anyscale-operator-1.8.0